### PR TITLE
Add packages read permission to license job

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -14,3 +14,4 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      packages: read


### PR DESCRIPTION
The maven dependency analysis needs to be able to fetch dependencies from Github Packages