### PR TITLE
Fix velocity calculation for crossings

### DIFF
--- a/java/bundles/org.eclipse.set.feature.table.pt1/src/org/eclipse/set/feature/table/pt1/sskw/SskwTransformator.xtend
+++ b/java/bundles/org.eclipse.set.feature.table.pt1/src/org/eclipse/set/feature/table/pt1/sskw/SskwTransformator.xtend
@@ -332,9 +332,6 @@ class SskwTransformator extends AbstractPlanPro2TableModelTransformator {
 
 			val keine_anlage = element.IDWKrAnlage === null
 
-			val isPMaxL = element.isGeschwindigkeitPMax(element.topKanteL)
-			val isPMaxR = element.isGeschwindigkeitPMax(element.topKanteR)
-
 			// M: Sskw.Weiche.v_zul_W.Links
 			val wKrGspKomponenten = element.WKrGspKomponenten
 			fillSwitch(
@@ -344,22 +341,17 @@ class SskwTransformator extends AbstractPlanPro2TableModelTransformator {
 				fillingIterableCase(
 					[art_ew_abw_ibw_kloth_dw_sonstige_mit_zungenpaar],
 					[
+						val isPMaxL = element.
+							isGeschwindigkeitPMax(element.topKanteL)
 						wKrGspKomponenten.map[zungenpaar].
 							printGeschwindingkeitL(isPMaxL)
 					]
 				),
 				fillingIterableCase(
-					[art_ekw],
+					[art_ekw || art_dkw],
 					[
-						wKrGspKomponenten.filter [
-							zungenpaar?.kreuzungsgleis?.wert ==
-								ENUM_LINKS_RECHTS_RECHTS
-						].map[zungenpaar].toList.printGeschwindingkeitL(isPMaxL)
-					]
-				),
-				fillingIterableCase(
-					[art_dkw],
-					[
+						val isPMaxL = element.
+							isGeschwindigkeitPMax(element.topKanteL)
 						wKrGspKomponenten.filter [
 							zungenpaar?.kreuzungsgleis?.wert ==
 								ENUM_LINKS_RECHTS_RECHTS
@@ -384,23 +376,16 @@ class SskwTransformator extends AbstractPlanPro2TableModelTransformator {
 				fillingIterableCase(
 					[art_ew_abw_ibw_kloth_dw_sonstige_mit_zungenpaar],
 					[
+						val isPMaxR = element.isGeschwindigkeitPMax(element.topKanteR)
 						wKrGspKomponenten.map [
 							zungenpaar
 						].printGeschwindingkeitR(isPMaxR)
 					]
 				),
 				fillingIterableCase(
-					[art_ekw],
+					[art_ekw || art_dkw],
 					[
-						wKrGspKomponenten.filter [
-							zungenpaar?.kreuzungsgleis?.wert ==
-								ENUM_LINKS_RECHTS_LINKS
-						].map[zungenpaar].toList.printGeschwindingkeitR(isPMaxR)
-					]
-				),
-				fillingIterableCase(
-					[art_dkw],
-					[
+						val isPMaxR = element.isGeschwindigkeitPMax(element.topKanteR)
 						wKrGspKomponenten.filter [
 							zungenpaar?.kreuzungsgleis?.wert ==
 								ENUM_LINKS_RECHTS_LINKS
@@ -433,6 +418,7 @@ class SskwTransformator extends AbstractPlanPro2TableModelTransformator {
 				fillingIterableCase(
 					[art_ekw],
 					[
+						val isPMaxL = element.isGeschwindigkeitPMax(element.topKanteL)
 						getKreuzungEKWGroup(wKrGspKomponenten,
 							ENUM_LINKS_RECHTS_LINKS).
 							printGeschwindingkeitL(isPMaxL)
@@ -441,6 +427,7 @@ class SskwTransformator extends AbstractPlanPro2TableModelTransformator {
 				fillingIterableCase(
 					[art_dkw && exKrLinksKomponenten],
 					[
+						val isPMaxL = element.isGeschwindigkeitPMax(element.topKanteL)
 						krLinksKomponenten.map [
 							zungenpaar
 						].toList.printGeschwindingkeitL(isPMaxL)
@@ -449,6 +436,7 @@ class SskwTransformator extends AbstractPlanPro2TableModelTransformator {
 				fillingIterableCase(
 					[art_kr_flachkreuzung_sonstige_mit_kreuzung],
 					[
+						val isPMaxL = element.isGeschwindigkeitPMax(element.topKanteL)
 						wKrGspKomponenten.map[kreuzung].
 							printGeschwindingkeitL(isPMaxL)
 					]
@@ -475,6 +463,7 @@ class SskwTransformator extends AbstractPlanPro2TableModelTransformator {
 				fillingIterableCase(
 					[art_ekw],
 					[
+						val isPMaxR = element.isGeschwindigkeitPMax(element.topKanteR)
 						getKreuzungEKWGroup(wKrGspKomponenten,
 							ENUM_LINKS_RECHTS_RECHTS).
 							printGeschwindingkeitR(isPMaxR)
@@ -483,6 +472,7 @@ class SskwTransformator extends AbstractPlanPro2TableModelTransformator {
 				fillingIterableCase(
 					[art_dkw && exKrRechtsKomponenten],
 					[
+						val isPMaxR = element.isGeschwindigkeitPMax(element.topKanteR)
 						krRechtsKomponenten.map [
 							zungenpaar
 						].toList.printGeschwindingkeitR(isPMaxR)
@@ -491,6 +481,7 @@ class SskwTransformator extends AbstractPlanPro2TableModelTransformator {
 				fillingIterableCase(
 					[art_kr_flachkreuzung_sonstige_mit_kreuzung],
 					[
+						val isPMaxR = element.isGeschwindigkeitPMax(element.topKanteR)
 						wKrGspKomponenten.map[kreuzung].
 							printGeschwindingkeitR(isPMaxR)
 					]

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/WKrGspElementExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/WKrGspElementExtensions.xtend
@@ -26,6 +26,7 @@ import org.eclipse.set.toolboxmodel.Weichen_und_Gleissperren.W_Kr_Gsp_Element
 import org.eclipse.set.toolboxmodel.Weichen_und_Gleissperren.W_Kr_Gsp_Komponente
 
 import static org.eclipse.set.toolboxmodel.Geodaten.ENUMTOPAnschluss.*
+import static org.eclipse.set.toolboxmodel.Weichen_und_Gleissperren.ENUMWKrArt.*
 
 import static extension org.eclipse.set.ppmodel.extensions.BereichObjektExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.PunktObjektExtensions.*
@@ -120,15 +121,30 @@ class WKrGspElementExtensions extends BasisObjektExtensions {
 	 * element is no Weiche
 	 */
 	def static TOP_Knoten getTopKnoten(W_Kr_Gsp_Element wKrGspElement) {
-		if (wKrGspElement?.weicheElement === null) {
-			return null
+		switch (wKrGspElement.getWKrAnlage.getWKrAnlageAllg.getWKrArt) {
+			case ENUMW_KR_ART_KLOTHOIDENWEICHE,
+			case ENUMW_KR_ART_IBW,
+			case ENUMW_KR_ART_KORBBOGENWEICHE,
+			case ENUMW_KR_ART_ABW,
+			case ENUMW_KR_ART_DKW,
+			case ENUMW_KR_ART_DW,
+			case ENUMW_KR_ART_EKW,
+			case ENUMW_KR_ART_EW: {
+				if (wKrGspElement?.weicheElement === null) {
+					return null
+				}
+				val zungenpaare = wKrGspElement.WKrGspKomponenten.filter [
+					zungenpaar !== null
+				]
+				Assert.isTrue(!zungenpaare.empty)
+				val zungenpaar = zungenpaare.get(0)
+				return zungenpaar.topKnoten
+			}
+			case ENUMW_KR_ART_FLACHKREUZUNG,
+			case ENUMW_KR_ART_KR,
+			case ENUMW_KR_ART_SONSTIGE:
+				return wKrGspElement.WKrGspKomponenten.get(0).topKnoten
 		}
-		val zungenpaare = wKrGspElement.WKrGspKomponenten.filter [
-			zungenpaar !== null
-		]
-		Assert.isTrue(!zungenpaare.empty)
-		val zungenpaar = zungenpaare.get(0)
-		return zungenpaar.topKnoten
 	}
 
 	/**
@@ -166,9 +182,9 @@ class WKrGspElementExtensions extends BasisObjektExtensions {
 	static def Set<Fstr_Zug_Rangier> getFstrZugCrossingLeg(
 		W_Kr_Gsp_Element element, TOP_Kante legTopKante) {
 		return element.container.fstrZugRangier.filter [
-			fstrZug !== null &&
-				IDFstrFahrweg.bereichObjektTeilbereich.map[topKante].contains(
-					legTopKante)
+			fstrZug !== null && IDFstrFahrweg.bereichObjektTeilbereich.map [
+				topKante
+			].contains(legTopKante)
 		].filterNull.toSet
 	}
 }


### PR DESCRIPTION
A crossing does not have a zungenpaar, thus only consider the first WKr_Gsp_Komponente for determining the TOP_Punkt