### PR TITLE
Fix show folder dialog opening the wrong folder after exporting

### DIFF
--- a/java/bundles/org.eclipse.set.feature.plazmodel/src/org/eclipse/set/feature/plazmodel/PlazModelPart.java
+++ b/java/bundles/org.eclipse.set.feature.plazmodel/src/org/eclipse/set/feature/plazmodel/PlazModelPart.java
@@ -185,7 +185,7 @@ public class PlazModelPart extends AbstractEmfFormsPart {
 				ValidationProblemExtensions::getCsvExport);
 		optionalPath.ifPresent(
 				outputDir -> getDialogService().openDirectoryAfterExport(
-						getToolboxShell(), Paths.get(defaultPath)));
+						getToolboxShell(), outputDir.getParent()));
 	}
 
 	@Override

--- a/java/bundles/org.eclipse.set.feature.validation/src/org/eclipse/set/feature/validation/parts/ValidationPart.java
+++ b/java/bundles/org.eclipse.set.feature.validation/src/org/eclipse/set/feature/validation/parts/ValidationPart.java
@@ -279,7 +279,7 @@ public class ValidationPart extends AbstractEmfFormsPart {
 				ValidationProblemExtensions::getCsvExport);
 		optionalPath.ifPresent(
 				outputDir -> part.getDialogService().openDirectoryAfterExport(
-						part.getToolboxShell(), Paths.get(defaultPath)));
+						part.getToolboxShell(), outputDir.getParent()));
 	}
 
 	void showValidationTable() {


### PR DESCRIPTION
Instead of showing the defaultDir, we should show the folder selected by the user