### PR TITLE
Fix incorrect validation results when missing layout xml

### DIFF
--- a/java/bundles/org.eclipse.set.feature.validation/src/org/eclipse/set/feature/validation/report/SessionToValidationReportTransformation.xtend
+++ b/java/bundles/org.eclipse.set.feature.validation/src/org/eclipse/set/feature/validation/report/SessionToValidationReportTransformation.xtend
@@ -74,12 +74,15 @@ class SessionToValidationReportTransformation {
 		problems.addAll(
 			session.getValidationResult(PlanPro_Schnittstelle).transform(
 				session?.toolboxFile, session?.toolboxFile?.modelPath))
-		problems.addAll(
-			session.getValidationResult(PlanPro_Layoutinfo).transform(
-				session?.toolboxFile, session?.toolboxFile?.layoutPath).filter [
-				!problems.contains(it)
-			]
-		)
+		val layoutValidation = session.getValidationResult(PlanPro_Layoutinfo)
+		if (layoutValidation !== null) {
+			problems.addAll(
+				layoutValidation.transform(session?.toolboxFile,
+					session?.toolboxFile?.layoutPath).filter [
+					!problems.contains(it)
+				]
+			)
+		}
 		problems.sortProblem
 		report.problems.addAll(problems)
 		// Add subwork information
@@ -272,15 +275,21 @@ class SessionToValidationReportTransformation {
 		return
 	}
 
-	private def ValidationProblem create ValidationreportFactory.eINSTANCE.createValidationProblem
-	transform(
+	private def ValidationProblem transform(
 		String errorType,
 		String message
 	) {
+		val it = ValidationreportFactory.eINSTANCE.createValidationProblem
 		type = errorType
 		severity = ValidationSeverity.SUCCESS
 		severityText = severity.translate
+		if (validationSourceClass == PlanPro_Layoutinfo) {
+			objectState = ObjectState.LAYOUT
+		} else {
+			objectState = ObjectState.INFO
+		}
 		it.message = message
+		return it
 	}
 
 	private def Iterable<String> getSubworkTypes(IModelSession session) {

--- a/java/bundles/org.eclipse.set.feature.validation/src/org/eclipse/set/feature/validation/session/ModelSession.java
+++ b/java/bundles/org.eclipse.set.feature.validation/src/org/eclipse/set/feature/validation/session/ModelSession.java
@@ -15,7 +15,6 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.EventObject;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -174,8 +173,7 @@ public class ModelSession implements IModelSession {
 	final ServiceProvider serviceProvider;
 	TableType tableType = null;
 	private SaveFixResult saveFixResult = SaveFixResult.NONE;
-	protected ValidationResult layoutinfoValidationResult = new ValidationResult(
-			PlanPro_Layoutinfo.class);
+	protected ValidationResult layoutinfoValidationResult = null;
 
 	/**
 	 * @param toolboxFile
@@ -463,9 +461,10 @@ public class ModelSession implements IModelSession {
 	@Override
 	public Outcome getValidationsOutcome(
 			final Function<ValidationResult, Outcome> outcome) {
-		final Stream<ValidationResult> resultsStream = List
+		final Stream<ValidationResult> resultsStream = Stream
 				.of(schnittstelleValidationResult, layoutinfoValidationResult)
-				.stream();
+				.filter(c -> c != null);
+
 		if (resultsStream
 				.anyMatch(result -> outcome.apply(result) == Outcome.INVALID)) {
 			return Outcome.INVALID;


### PR DESCRIPTION
If a planning data has no layout information, the XSD validation was always considered to have failed due to the default value in the model. Furthermore it was not possible to differenciate between success messages of the model XSD validation and the layout XSD validation.

This PR disables validation for missing layout information xml files and adds the Layout state tag to the success entries.