### PR TITLE
Download matching version of pdfjs dist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build
         run: |
-          wget --no-verbose -O pdfjs.zip https://github.com/mozilla/pdf.js/releases/download/v3.10.111/pdfjs-3.10.111-dist.zip
+          wget --no-verbose -O pdfjs.zip https://github.com/mozilla/pdf.js/releases/download/v$(node getVersion.js)/pdfjs-$(node getVersion.js)-dist.zip
           npm ci
           npm run build
         working-directory: web/pdf


### PR DESCRIPTION
At some point during the transition to Github actions I hardcoded the url to pdfjs dist. This now breaks the pdf viewer, as the API version and viewer version differ.

This PR reads the correct viewer version via node.