### PR TITLE
Fix getFstrZugCrossingLeg considering Fstrs outside the associated Bereich Objekt

### DIFF
--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/WKrGspElementExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/WKrGspElementExtensions.xtend
@@ -185,7 +185,7 @@ class WKrGspElementExtensions extends BasisObjektExtensions {
 			fstrZug !== null && IDFstrFahrweg.bereichObjektTeilbereich.map [
 				topKante
 			].contains(legTopKante) && element.getWKrGspKomponenten.exists [
-				fstrZR.IDFstrFahrweg.intersects(it)
+				fstrFW.intersects(it)
 			]
 		].filterNull.toSet
 	}

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/WKrGspElementExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/WKrGspElementExtensions.xtend
@@ -26,7 +26,6 @@ import org.eclipse.set.toolboxmodel.Weichen_und_Gleissperren.W_Kr_Gsp_Element
 import org.eclipse.set.toolboxmodel.Weichen_und_Gleissperren.W_Kr_Gsp_Komponente
 
 import static org.eclipse.set.toolboxmodel.Geodaten.ENUMTOPAnschluss.*
-import static org.eclipse.set.toolboxmodel.Weichen_und_Gleissperren.ENUMWKrArt.*
 
 import static extension org.eclipse.set.ppmodel.extensions.BereichObjektExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.PunktObjektExtensions.*
@@ -182,9 +181,12 @@ class WKrGspElementExtensions extends BasisObjektExtensions {
 	static def Set<Fstr_Zug_Rangier> getFstrZugCrossingLeg(
 		W_Kr_Gsp_Element element, TOP_Kante legTopKante) {
 		return element.container.fstrZugRangier.filter [
+			val fstrZR = it
 			fstrZug !== null && IDFstrFahrweg.bereichObjektTeilbereich.map [
 				topKante
-			].contains(legTopKante)
+			].contains(legTopKante) && element.getWKrGspKomponenten.exists [
+				fstrZR.IDFstrFahrweg.intersects(it)
+			]
 		].filterNull.toSet
 	}
 }

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/WKrGspElementExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/WKrGspElementExtensions.xtend
@@ -181,7 +181,7 @@ class WKrGspElementExtensions extends BasisObjektExtensions {
 	static def Set<Fstr_Zug_Rangier> getFstrZugCrossingLeg(
 		W_Kr_Gsp_Element element, TOP_Kante legTopKante) {
 		return element.container.fstrZugRangier.filter [
-			val fstrZR = it
+			val fstrFW = IDFstrFahrweg
 			fstrZug !== null && IDFstrFahrweg.bereichObjektTeilbereich.map [
 				topKante
 			].contains(legTopKante) && element.getWKrGspKomponenten.exists [


### PR DESCRIPTION
When determining the Fstr_Fahrweg for a given track switch crossing leg, we only considered the TOP_Kante to check if the track switch is included within the Fstr_Fahrweg. However this also incorrectly considered the case where a Fstr_Fahrweg starts at some point after the track switch leg. 