### PR TITLE
Remove unused @types/proj4 devDependency

### DIFF
--- a/web/siteplan/package.json
+++ b/web/siteplan/package.json
@@ -23,7 +23,6 @@
     "vuex": "^4.1.0"
   },
   "devDependencies": {
-    "@types/proj4": "^2.5.2",
     "@typescript-eslint/eslint-plugin": "^5.57.0",
     "@typescript-eslint/parser": "^5.57.0",
     "@vitejs/plugin-vue": "^4.4.0",


### PR DESCRIPTION
We no longer use the JS variant of proj4, so types can also be removed. 

Replaces #173