### PR TITLE
Sskp: Evaluate columns C-F for each DWeg

### DIFF
--- a/java/bundles/org.eclipse.set.feature.table.pt1/src/org/eclipse/set/feature/table/pt1/sskp/SskpTransformationService.java
+++ b/java/bundles/org.eclipse.set.feature.table.pt1/src/org/eclipse/set/feature/table/pt1/sskp/SskpTransformationService.java
@@ -8,12 +8,17 @@
  */
 package org.eclipse.set.feature.table.pt1.sskp;
 
+import java.util.List;
+
 import org.eclipse.set.core.services.enumtranslation.EnumTranslationService;
 import org.eclipse.set.feature.table.PlanPro2TableTransformationService;
 import org.eclipse.set.feature.table.pt1.AbstractPlanPro2TableModelTransformator;
 import org.eclipse.set.feature.table.pt1.AbstractPlanPro2TableTransformationService;
 import org.eclipse.set.feature.table.pt1.messages.Messages;
+import org.eclipse.set.model.tablemodel.ColumnDescriptor;
+import org.eclipse.set.model.tablemodel.RowMergeMode;
 import org.eclipse.set.ppmodel.extensions.utils.TableNameInfo;
+import org.eclipse.set.utils.table.ColumnDescriptorModelBuilder;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -55,5 +60,24 @@ public final class SskpTransformationService
 	@Override
 	protected String getTableHeading() {
 		return messages.SskpTableView_Heading;
+	}
+
+	@Override
+	public ColumnDescriptor fillHeaderDescriptions(
+			final ColumnDescriptorModelBuilder builder) {
+		final ColumnDescriptor cd = super.fillHeaderDescriptions(builder);
+		// Merge all columns except C to F
+		cd.setMergeCommonValues(RowMergeMode.ENABLED);
+		List.of(SskpColumns.PZB_Schutzpunkt, //
+				SskpColumns.GeschwindigkeitsKlasse, //
+				SskpColumns.PZB_Schutzstrecke_Soll, //
+				SskpColumns.PZB_Schutzstrecke_Ist)
+				.forEach(it -> cols.forEach(col -> {
+					if (it.equals(col.getColumnPosition())) {
+						col.setMergeCommonValues(RowMergeMode.DISABLED);
+					}
+				}));
+
+		return cd;
 	}
 }

--- a/java/bundles/org.eclipse.set.feature.table.pt1/src/org/eclipse/set/feature/table/pt1/sskp/SskpTransformator.xtend
+++ b/java/bundles/org.eclipse.set.feature.table.pt1/src/org/eclipse/set/feature/table/pt1/sskp/SskpTransformator.xtend
@@ -12,12 +12,14 @@ import java.util.Set
 import org.eclipse.set.core.services.enumtranslation.EnumTranslationService
 import org.eclipse.set.feature.table.pt1.AbstractPlanPro2TableModelTransformator
 import org.eclipse.set.model.tablemodel.ColumnDescriptor
+import org.eclipse.set.model.tablemodel.TableRow
 import org.eclipse.set.ppmodel.extensions.container.MultiContainer_AttributeGroup
 import org.eclipse.set.ppmodel.extensions.utils.Case
 import org.eclipse.set.ppmodel.extensions.utils.TopGraph
 import org.eclipse.set.toolboxmodel.Bahnsteig.Bahnsteig_Kante
 import org.eclipse.set.toolboxmodel.Basisobjekte.Basis_Objekt
 import org.eclipse.set.toolboxmodel.Basisobjekte.Punkt_Objekt
+import org.eclipse.set.toolboxmodel.Fahrstrasse.Fstr_DWeg
 import org.eclipse.set.toolboxmodel.PZB.ENUMPZBArt
 import org.eclipse.set.toolboxmodel.PZB.ENUMWirksamkeitFstr
 import org.eclipse.set.toolboxmodel.PZB.PZB_Element
@@ -32,7 +34,9 @@ import org.eclipse.set.utils.table.TMFactory
 import static org.eclipse.set.basis.constants.ToolboxConstants.NUMERIC_COMPARATOR
 import static org.eclipse.set.feature.table.pt1.sskp.SskpColumns.*
 
+import static extension org.eclipse.set.basis.graph.Digraphs.*
 import static extension org.eclipse.set.ppmodel.extensions.BasisAttributExtensions.*
+import static extension org.eclipse.set.ppmodel.extensions.BasisObjektExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.BereichObjektExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.FstrZugRangierExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.PZBElementExtensions.*
@@ -42,11 +46,9 @@ import static extension org.eclipse.set.ppmodel.extensions.SignalRahmenExtension
 import static extension org.eclipse.set.ppmodel.extensions.SignalbegriffExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.TopKanteExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.WKrGspElementExtensions.*
-import static extension org.eclipse.set.basis.graph.Digraphs.*
 import static extension org.eclipse.set.utils.math.BigDecimalExtensions.*
 import static extension org.eclipse.set.utils.math.BigIntegerExtensions.*
 import static extension org.eclipse.set.utils.math.DoubleExtensions.*
-import static extension org.eclipse.set.ppmodel.extensions.BasisObjektExtensions.*
 
 /**
  * Table transformation for a PZB-Tabelle (Sskp)
@@ -57,6 +59,7 @@ class SskpTransformator extends AbstractPlanPro2TableModelTransformator {
 	static final double ADDITION_SCHUTZSTRECKE_SOLL_60 = 450
 	static final double ADDITION_SCHUTZSTRECKE_SOLL_40_60 = 350
 	static final double ADDITION_SCHUTZSTRECKE_SOLL_40 = 210
+
 	new(Set<ColumnDescriptor> cols,
 		EnumTranslationService enumTranslationService) {
 		super(cols, enumTranslationService)
@@ -64,456 +67,450 @@ class SskpTransformator extends AbstractPlanPro2TableModelTransformator {
 
 	override transformTableContent(MultiContainer_AttributeGroup container,
 		TMFactory factory) {
+
 		val topGraph = new TopGraph(container.TOPKante)
 		for (PZB_Element pzb : container.PZBElement) {
 			if (Thread.currentThread.interrupted) {
 				return null
 			}
-			val instance = factory.newTableRow(pzb)
+			val rg = factory.newRowGroup(pzb)
 
-			// A: Sskp.Bezug.BezugsElement
-			fillIterable(
-				instance,
-				cols.getColumn(Bezugselement),
-				pzb,
-				[PZBElementBezugspunkt.map[fillBezugsElement]],
-				MIXED_STRING_COMPARATOR
-			)
-
-			// B: Sskp.Bezug.Wirkfrequenz
-			fill(
-				instance,
-				cols.getColumn(Wirkfrequenz),
-				pzb,
-				[PZBArt?.wert?.translate]
-			)
-
-			val isPZB2000 = pzb.PZBArt?.wert ===
-				ENUMPZBArt.ENUMPZB_ART_2000_HZ ||
-				pzb.PZBArt?.wert === ENUMPZBArt.ENUMPZB_ART_1000_2000_HZ
-
-			// C: Sskp.PZB_Schutzstrecke.PZB_Schutzpunkt
-			fillIterableWithConditional(
-				instance,
-				cols.getColumn(PZB_Schutzpunkt),
-				pzb,
-				[isPZB2000],
-				[
-					fstrDWegs?.map[IDPZBGefahrpunkt]?.filterNull.map [
-						bezeichnung?.bezeichnungMarkanterPunkt?.wert
-					]
-				],
-				MIXED_STRING_COMPARATOR,
-				ITERABLE_FILLING_SEPARATOR
-			)
-
-			// D: Sskp.PZB_Schutzstrecke.GeschwindigkeitsKlasse
-			fillIterableWithConditional(
-				instance,
-				cols.getColumn(GeschwindigkeitsKlasse),
-				pzb,
-				[isPZB2000],
-				[
-					fstrDWegs?.filter[IDPZBGefahrpunkt !== null]?.map [
-						val dwegV = fstrDWegSpezifisch?.DWegV?.wert.toInteger
-						if (dwegV === 0) {
-							return ""
-						}
-						if (dwegV > 60) {
-							return "v > 60"
-						} else if (dwegV <= 60 && dwegV > 40) {
-							return "40 < v ≤ 60"
-						} else if (dwegV <= 40) {
-							return "v ≤ 40"
-						}
-						return ""
-					]
-				],
-				MIXED_STRING_COMPARATOR,
-				ITERABLE_FILLING_SEPARATOR
-			)
-
-			// E: Sskp.PZB_Schutzstrecke.PZB_Schutzstr.PZB_Schutzstrecke_Soll
-			fillIterableWithConditional(
-				instance,
-				cols.getColumn(PZB_Schutzstrecke_Soll),
-				pzb,
-				[isPZB2000],
-				[
-					fstrDWegs?.filter[IDPZBGefahrpunkt !== null]?.map [
-						val dwegV = fstrDWegSpezifisch?.DWegV?.wert.toInteger
-						val inclination = fstrDWegAllg?.massgebendeNeigung?.wert.toDouble
-						val multipleValue = inclination < 0 ? 0.05 : 0.1
-						if (dwegV === 0) {
-							return ""
-						}
-						
-						if (dwegV > 60) {
-							return '''«inclination * multipleValue * 200 + ADDITION_SCHUTZSTRECKE_SOLL_60»'''
-						} else if (dwegV <= 60 && dwegV > 40) {
-							return '''«inclination * multipleValue * 100 + ADDITION_SCHUTZSTRECKE_SOLL_40_60»'''
-						} else if (dwegV <= 40) {
-							return '''«inclination * multipleValue * 50 + ADDITION_SCHUTZSTRECKE_SOLL_40»'''
-						}
-						return ""
-					]
-				],
-				MIXED_STRING_COMPARATOR,
-				ITERABLE_FILLING_SEPARATOR
-			)
-
-			// F: Sskp.PZB_Schutzstrecke.PZB_Schutzstr.PZB_Schutzstrecke_Ist
-			fillIterableWithConditional(
-				instance,
-				cols.getColumn(PZB_Schutzstrecke_Ist),
-				pzb,
-				[
-					!fstrDWegs.map[IDPZBGefahrpunkt].empty
-				],
-				[
-					PZBElementBezugspunkt.filter(Signal).map [ signal |
-						val markantePunkts = fstrDWegs.map [ dweg |
-							dweg?.IDPZBGefahrpunkt?.IDMarkanteStelle
-						].filter(Punkt_Objekt)
-						return getDistanceOfPoints(topGraph, markantePunkts,
-							signal)
-					]
-				],
-				null,
-				ITERABLE_FILLING_SEPARATOR
-			)
-
-			// G: Sskp.Gleismagnete.Wirksamkeit
-			fillIterable(
-				instance,
-				cols.getColumn(Wirksamkeit),
-				pzb,
-				[
-					PZBElementZuordnungBP.map [
-						wirksamkeit?.wert?.translate
-					]
-				],
-				null
-			)
-
-			// H: Sskp.Gleismagnete.Wirksamkeit_Bedingung
-			val bueSpezifischeSignals = pzb.container.BUESpezifischesSignal.
-				filter [
-					pzb.PZBElementBezugspunkt.filter(Signal).filter [
-						signalReal.signalFunktion.wert === ENUMSignalFunktion.
-							ENUM_SIGNAL_FUNKTION_BUE_UEBERWACHUNGSSIGNAL
-					].exists[signal|signal === IDSignal]
-				]
-			fillSwitch(
-				instance,
-				cols.getColumn(Wirksamkeit_Bedingung),
-				pzb,
-				new Case<PZB_Element>(
-					[
-						!PZBElementZuordnungFstr.map[IDFstrZugRangier].empty ||
-							(PZBElementGUE !== null &&
-								PZBElementZuordnungFstr.exists [
-									wirksamkeitFstr?.wert ===
-										ENUMWirksamkeitFstr.
-											ENUM_WIRKSAMKEIT_FSTR_STAENDIG_WIRKSAM_WENN_FAHRSTRASSE_EINGESTELLT
-								])
-					],
-					[
-						PZBElementZuordnungFstr.map [
-							val wirksamKeit = wirksamkeitFstr?.wert?.translate
-							val fstrZugRangier = IDFstrZugRangier.
-								getZugFstrBezeichnung([art|isZ(art)])
-							return '''«wirksamKeit» «fstrZugRangier»'''
-						]
-					],
-					ITERABLE_FILLING_SEPARATOR,
-					null
-				),
-				new Case<PZB_Element>(
-					[
-						PZBElementZuordnungFstr.exists [
-							wirksamkeitFstr?.wert == ENUMWirksamkeitFstr.
-								ENUM_WIRKSAMKEIT_FSTR_SONSTIGE
-						]
-					],
-					[
-						IDPZBElementZuordnung.bearbeitungsvermerk.map [
-							bearbeitungsvermerkAllg?.kurztext?.wert
-						]
-					],
-					ITERABLE_FILLING_SEPARATOR,
-					MIXED_STRING_COMPARATOR
-				),
-				new Case<PZB_Element>(
-					[!bueSpezifischeSignals.empty],
-					[
-						bueSpezifischeSignals.map [
-							IDBUEAnlage?.bezeichnung?.bezeichnungTabelle?.wert
-						]
-					],
-					ITERABLE_FILLING_SEPARATOR,
-					MIXED_STRING_COMPARATOR
-				)
-			)
-
-			// I: Sskp.Gleismagnete.Abstand_Signal_Weiche
-			fillIterable(
-				instance,
-				cols.getColumn(Abstand_Signal_Weiche),
-				pzb,
-				[
-					PZBElementBezugspunkt.map [
-						getDistanceSignalTrackSwtich(topGraph, pzb, it)
-					]
-				],
-				null
-			)
-
-			// J: Sskp.Gleismagnete.Abstand_GM_2000
-			fillSwitch(
-				instance,
-				cols.getColumn(Abstand_GM_2000),
-				pzb,
-				new Case<PZB_Element>(
-					[PZBArt?.wert === ENUMPZBArt.ENUMPZB_ART_500_HZ],
-					[
-						""
-					]
-				),
-				new Case<PZB_Element>(
-					[PZBArt?.wert === ENUMPZBArt.ENUMPZB_ART_1000_HZ],
-					[
-						val bezugspunktSignals = PZBElementBezugspunkt.filter(
-							Signal)
-						val pzbZuordnungSignals = PZBZuordnungSignal.map [
-							IDSignal
-						]
-						val distance = bezugspunktSignals.filter [
-							pzbZuordnungSignals.contains(it)
-						].map [
-							AgateRounding.roundDown(
-								topGraph.getPointsDistance(pzb, it).min)
-						].filter[it !== 0]
-						return distance.map[it.toString]
-					],
-					ITERABLE_FILLING_SEPARATOR,
-					NUMERIC_COMPARATOR
-				)
-			)
-
-			if (pzb.PZBElementZuordnungBP.exists [
-				PZBElementZuordnungINA !== null
-			] && (pzb.PZBArt?.wert === ENUMPZBArt.ENUMPZB_ART_2000_HZ ||
-				pzb.PZBArt?.wert === ENUMPZBArt.ENUMPZB_ART_1000_2000_HZ)) {
-				val inaGefahrstelles = pzb.PZBElementZuordnungBP.map [
-					INAGefahrstelle
-				].flatten
-
-				val isGefahrstelle = inaGefahrstelles.exists [
-					prioritaetGefahrstelle?.wert.intValue === 1
-				] && !inaGefahrstelles.map[IDMarkanterPunkt].empty
-				// K: Sskp.Ina.Gef_Stelle
-				fillIterableWithConditional(
-					instance,
-					cols.getColumn(Gef_Stelle),
-					pzb,
-					[isGefahrstelle],
-					[
-						inaGefahrstelles.map [
-							IDMarkanterPunkt?.bezeichnung?.
-								bezeichnungMarkanterPunkt?.wert
-						]
-					],
-					MIXED_STRING_COMPARATOR,
-					ITERABLE_FILLING_SEPARATOR
-				)
-
-				// L: Sskp.Ina.Gef_Stelle_abstand
-				fillConditional(
-					instance,
-					cols.getColumn(Gef_Stelle_Abstand),
-					pzb,
-					[isGefahrstelle],
-					[
-						val markanteStelle = inaGefahrstelles.map [
-							IDMarkanterPunkt?.IDMarkanteStelle
-						].filter(Punkt_Objekt)
-						return getDistanceOfPoints(topGraph, markanteStelle, it)
-					]
-				)
-
-				val bahnSteigKantes = pzb?.PZBElementZuordnungBP?.map [
-					PZBElementZuordnungINA
-				]?.map[IDBahnsteigKante]
-				val bahnSteigAbstand = bahnSteigKantes.map [
-					pzb.getBahnsteigAbstand(it)
-				].flatten
-				// M: Sskp.Ina.Abstand_GM_2000_Bahnsteig.Abstand_GM_2000_Bahnsteig_Anfang
-				fillConditional(
-					instance,
-					cols.getColumn(Abstand_GM_2000_Bahnsteig_Anfang),
-					pzb,
-					[!bahnSteigKantes.empty],
-					[
-						bahnSteigAbstand.max.toTableInteger
-					]
-				)
-
-				// N: Sskp.Ina.Abstand_GM_2000_Bahnsteig.Abstand_GM_2000_Bahnsteig_Ende
-				fillConditional(
-					instance,
-					cols.getColumn(Abstand_GM_2000_Bahnsteig_Ende),
-					pzb,
-					[!bahnSteigKantes.empty],
-					[
-						bahnSteigAbstand.min.toTableInteger
-					]
-				)
-
-				// O: Sskp.Ina.H-Tafel_Abstand
-				fillIterableWithConditional(
-					instance,
-					cols.getColumn(H_Tafel_Abstand),
-					pzb,
-					[
-						PZBZuordnungSignal?.map[IDSignal?.signalRahmen].flatten.
-							map[signalbegriffe].flatten.exists [
-								hasSignalbegriffID(Ne5)
-							]
-					],
-					[
-						PZBZuordnungSignal?.map[IDSignal].map [ signal |
-							getPointsDistance(topGraph, pzb, signal).min
-						].filter[it.doubleValue === 0.0].map [
-							AgateRounding.roundDown(it).toString
-						]
-					],
-					NUMERIC_COMPARATOR,
-					ITERABLE_FILLING_SEPARATOR
-				)
-
-				// P: Sskp.Ina.Abstand_VorsignalWdh_GM_2000
-				fillIterableWithConditional(
-					instance,
-					cols.getColumn(Abstand_vorsignalWdh_GM_2000),
-					pzb,
-					[
-						PZBZuordnungSignal?.map[IDSignal].exists [
-							signalReal?.signalRealAktivSchirm?.signalArt?.
-								wert === ENUMSignalArt.
-								ENUM_SIGNAL_ART_VORSIGNALWIEDERHOLER
-						]
-					],
-					[
-						PZBZuordnungSignal?.map[IDSignal].map [ signal |
-							getPointsDistance(topGraph, pzb, signal).min
-						].filter[it.doubleValue === 0.0].map [
-							AgateRounding.roundDown(it).toString
-						]
-					],
-					NUMERIC_COMPARATOR,
-					ITERABLE_FILLING_SEPARATOR
-				)
-
-				// Q: Sskp.Ina.Prüfdatum_Wirkbereichsbogen
-				// Fill Attribute exixts first on Model 1.11
-				fill(
-					instance,
-					cols.getColumn(Pruefdatum_Wirkbereichsbogen),
-					pzb,
-					[""]
-				)
-
-			} else {
-				for (var i = 9; i < 15; i++) {
-					fillBlank(instance, i)
-				}
-			}
-
-			if (pzb.PZBElementGUE !== null) {
-				// R: Sskp.Gue.Pruefgeschwindigkeit
-				fill(
-					instance,
-					cols.getColumn(Pruefgeschwindigkeit),
-					pzb,
-					[PZBElementGUE.pruefgeschwindigkeit?.wert.intValue.toString]
-				)
-
-				// S: Sskp.Gue.Pruefzeit
-				fill(
-					instance,
-					cols.getColumn(Pruefzeit),
-					pzb,
-					[PZBElementGUE.pruefzeit?.wert.toTableInteger]
-				)
-
-				// T: Sskp.Gue.Messfehler
-				fill(
-					instance,
-					cols.getColumn(Messfehler),
-					pzb,
-					[PZBElementGUE.messfehler?.wert.translate]
-				)
-
-				// U: Sskp.Gue.Messstrecke
-				fill(
-					instance,
-					cols.getColumn(Messstrecke),
-					pzb,
-					[PZBElementGUE.GUEMessstrecke?.wert.intValue.toString]
-				)
-
-				// V: Sskp.Gue.GUE_Anordnung
-				fill(
-					instance,
-					cols.getColumn(GUE_Anordnung),
-					pzb,
-					[PZBElementGUE.GUEAnordnung?.wert.translate]
-				)
-
-				// W: Sskp.Gue.GUE_Bauart
-				fill(
-					instance,
-					cols.getColumn(GUE_Bauart),
-					pzb,
-					[PZBElementGUE.GUEBauart?.wert.translate]
-				)
-
-				// X: SSkp.Gue.Montageort_Schaltkastens
-				fill(
-					instance,
-					cols.getColumn(Montageort_Schaltkastens),
-					pzb,
-					[
-						IDUnterbringung?.unterbringungAllg?.
-							unterbringungBefestigung?.wert.translate
-					]
-				)
-
-				// Y: Sskp.Gue.Energieversorgung
-				fill(
-					instance,
-					cols.getColumn(Energieversorgung),
-					pzb,
-					[PZBElementGUE.GUEEnergieversorgung?.wert.translate]
-				)
-			} else {
-				for (var i = 15; i < 23; i++) {
-					fillBlank(instance, i)
-				}
-			}
-
-			// Z: Sskp.Bemerkung
-			fill(
-				instance,
-				cols.getColumn(Bemerkung),
-				pzb,
-				[]
-			)
-
+			pzb.fstrDWegs.forEach [
+				val instance = rg.newTableRow()
+				fillRowGroupContent(instance, pzb, it, topGraph)
+			]
 		}
 
 		return factory.table
+	}
+
+	private def fillRowGroupContent(TableRow instance, PZB_Element pzb,
+		Fstr_DWeg dweg, TopGraph topGraph) {
+		// A: Sskp.Bezug.BezugsElement
+		fillIterable(
+			instance,
+			cols.getColumn(Bezugselement),
+			pzb,
+			[PZBElementBezugspunkt.map[fillBezugsElement]],
+			MIXED_STRING_COMPARATOR
+		)
+
+		// B: Sskp.Bezug.Wirkfrequenz
+		fill(
+			instance,
+			cols.getColumn(Wirkfrequenz),
+			pzb,
+			[PZBArt?.wert?.translate]
+		)
+
+		val isPZB2000 = pzb.PZBArt?.wert === ENUMPZBArt.ENUMPZB_ART_2000_HZ ||
+			pzb.PZBArt?.wert === ENUMPZBArt.ENUMPZB_ART_1000_2000_HZ
+
+		// C: Sskp.PZB_Schutzstrecke.PZB_Schutzpunkt
+		fillConditional(
+			instance,
+			cols.getColumn(PZB_Schutzpunkt),
+			dweg,
+			[isPZB2000],
+			[
+				IDPZBGefahrpunkt?.bezeichnung?.bezeichnungMarkanterPunkt?.wert
+			]
+		)
+
+		// D: Sskp.PZB_Schutzstrecke.GeschwindigkeitsKlasse
+		fillConditional(
+			instance,
+			cols.getColumn(GeschwindigkeitsKlasse),
+			dweg,
+			[isPZB2000 && IDPZBGefahrpunkt !== null],
+			[
+				val dwegV = fstrDWegSpezifisch?.DWegV?.wert.toInteger
+				if (dwegV === 0) {
+					return ""
+				}
+				if (dwegV > 60) {
+					return "v > 60"
+				} else if (dwegV <= 60 && dwegV > 40) {
+					return "40 < v ≤ 60"
+				} else if (dwegV <= 40) {
+					return "v ≤ 40"
+				}
+				return ""
+
+			]
+		)
+
+		// E: Sskp.PZB_Schutzstrecke.PZB_Schutzstr.PZB_Schutzstrecke_Soll
+		fillConditional(
+			instance,
+			cols.getColumn(PZB_Schutzstrecke_Soll),
+			dweg,
+			[isPZB2000 && IDPZBGefahrpunkt !== null],
+			[
+				val dwegV = fstrDWegSpezifisch?.DWegV?.wert.toInteger
+				val inclination = fstrDWegAllg?.massgebendeNeigung?.wert.
+					toDouble
+				val multipleValue = inclination < 0 ? 0.05 : 0.1
+				if (dwegV === 0) {
+					return ""
+				}
+
+				if (dwegV > 60) {
+					return '''«inclination * multipleValue * 200 + ADDITION_SCHUTZSTRECKE_SOLL_60»'''
+				} else if (dwegV <= 60 && dwegV > 40) {
+					return '''«inclination * multipleValue * 100 + ADDITION_SCHUTZSTRECKE_SOLL_40_60»'''
+				} else if (dwegV <= 40) {
+					return '''«inclination * multipleValue * 50 + ADDITION_SCHUTZSTRECKE_SOLL_40»'''
+				}
+				return ""
+			]
+		)
+
+		// F: Sskp.PZB_Schutzstrecke.PZB_Schutzstr.PZB_Schutzstrecke_Ist
+		fillConditional(
+			instance,
+			cols.getColumn(PZB_Schutzstrecke_Ist),
+			dweg,
+			[
+				IDPZBGefahrpunkt !== null
+			],
+			[
+				val markanteStelle = dweg?.IDPZBGefahrpunkt?.IDMarkanteStelle
+				if (markanteStelle instanceof Punkt_Objekt)
+					return AgateRounding.roundDown(
+						getPointsDistance(topGraph, markanteStelle,
+							dweg.IDFstrFahrweg?.IDStart).min).toString
+				else
+					return ""
+			]
+		)
+
+		// G: Sskp.Gleismagnete.Wirksamkeit
+		fillIterable(
+			instance,
+			cols.getColumn(Wirksamkeit),
+			pzb,
+			[
+				PZBElementZuordnungBP.map [
+					wirksamkeit?.wert?.translate
+				]
+			],
+			null
+		)
+
+		// H: Sskp.Gleismagnete.Wirksamkeit_Bedingung
+		val bueSpezifischeSignals = pzb.container.BUESpezifischesSignal.filter [
+			pzb.PZBElementBezugspunkt.filter(Signal).filter [
+				signalReal.signalFunktion.wert === ENUMSignalFunktion.
+					ENUM_SIGNAL_FUNKTION_BUE_UEBERWACHUNGSSIGNAL
+			].exists[signal|signal === IDSignal]
+		]
+		fillSwitch(
+			instance,
+			cols.getColumn(Wirksamkeit_Bedingung),
+			pzb,
+			new Case<PZB_Element>(
+				[
+					!PZBElementZuordnungFstr.map[IDFstrZugRangier].empty ||
+						(PZBElementGUE !== null &&
+							PZBElementZuordnungFstr.exists [
+								wirksamkeitFstr?.wert === ENUMWirksamkeitFstr.
+									ENUM_WIRKSAMKEIT_FSTR_STAENDIG_WIRKSAM_WENN_FAHRSTRASSE_EINGESTELLT
+							])
+				],
+				[
+					PZBElementZuordnungFstr.map [
+						val wirksamKeit = wirksamkeitFstr?.wert?.translate
+						val fstrZugRangier = IDFstrZugRangier.
+							getZugFstrBezeichnung([art|isZ(art)])
+						return '''«wirksamKeit» «fstrZugRangier»'''
+					]
+				],
+				ITERABLE_FILLING_SEPARATOR,
+				null
+			),
+			new Case<PZB_Element>(
+				[
+					PZBElementZuordnungFstr.exists [
+						wirksamkeitFstr?.wert == ENUMWirksamkeitFstr.
+							ENUM_WIRKSAMKEIT_FSTR_SONSTIGE
+					]
+				],
+				[
+					IDPZBElementZuordnung.bearbeitungsvermerk.map [
+						bearbeitungsvermerkAllg?.kurztext?.wert
+					]
+				],
+				ITERABLE_FILLING_SEPARATOR,
+				MIXED_STRING_COMPARATOR
+			),
+			new Case<PZB_Element>(
+				[!bueSpezifischeSignals.empty],
+				[
+					bueSpezifischeSignals.map [
+						IDBUEAnlage?.bezeichnung?.bezeichnungTabelle?.wert
+					]
+				],
+				ITERABLE_FILLING_SEPARATOR,
+				MIXED_STRING_COMPARATOR
+			)
+		)
+
+		// I: Sskp.Gleismagnete.Abstand_Signal_Weiche
+		fillIterable(
+			instance,
+			cols.getColumn(Abstand_Signal_Weiche),
+			pzb,
+			[
+				PZBElementBezugspunkt.map [
+					getDistanceSignalTrackSwtich(topGraph, pzb, it)
+				]
+			],
+			null
+		)
+
+		// J: Sskp.Gleismagnete.Abstand_GM_2000
+		fillSwitch(
+			instance,
+			cols.getColumn(Abstand_GM_2000),
+			pzb,
+			new Case<PZB_Element>(
+				[PZBArt?.wert === ENUMPZBArt.ENUMPZB_ART_500_HZ],
+				[
+					""
+				]
+			),
+			new Case<PZB_Element>(
+				[PZBArt?.wert === ENUMPZBArt.ENUMPZB_ART_1000_HZ],
+				[
+					val bezugspunktSignals = PZBElementBezugspunkt.filter(
+						Signal)
+					val pzbZuordnungSignals = PZBZuordnungSignal.map [
+						IDSignal
+					]
+					val distance = bezugspunktSignals.filter [
+						pzbZuordnungSignals.contains(it)
+					].map [
+						AgateRounding.roundDown(
+							topGraph.getPointsDistance(pzb, it).min)
+					].filter[it !== 0]
+					return distance.map[it.toString]
+				],
+				ITERABLE_FILLING_SEPARATOR,
+				NUMERIC_COMPARATOR
+			)
+		)
+
+		if (pzb.PZBElementZuordnungBP.exists [
+			PZBElementZuordnungINA !== null
+		] && (pzb.PZBArt?.wert === ENUMPZBArt.ENUMPZB_ART_2000_HZ ||
+			pzb.PZBArt?.wert === ENUMPZBArt.ENUMPZB_ART_1000_2000_HZ)) {
+			val inaGefahrstelles = pzb.PZBElementZuordnungBP.map [
+				INAGefahrstelle
+			].flatten
+
+			val isGefahrstelle = inaGefahrstelles.exists [
+				prioritaetGefahrstelle?.wert.intValue === 1
+			] && !inaGefahrstelles.map[IDMarkanterPunkt].empty
+			// K: Sskp.Ina.Gef_Stelle
+			fillIterableWithConditional(
+				instance,
+				cols.getColumn(Gef_Stelle),
+				pzb,
+				[isGefahrstelle],
+				[
+					inaGefahrstelles.map [
+						IDMarkanterPunkt?.bezeichnung?.
+							bezeichnungMarkanterPunkt?.wert
+					]
+				],
+				MIXED_STRING_COMPARATOR,
+				ITERABLE_FILLING_SEPARATOR
+			)
+
+			// L: Sskp.Ina.Gef_Stelle_abstand
+			fillConditional(
+				instance,
+				cols.getColumn(Gef_Stelle_Abstand),
+				pzb,
+				[isGefahrstelle],
+				[
+					val markanteStelle = inaGefahrstelles.map [
+						IDMarkanterPunkt?.IDMarkanteStelle
+					].filter(Punkt_Objekt)
+					return getDistanceOfPoints(topGraph, markanteStelle, it)
+				]
+			)
+
+			val bahnSteigKantes = pzb?.PZBElementZuordnungBP?.map [
+				PZBElementZuordnungINA
+			]?.map[IDBahnsteigKante]
+			val bahnSteigAbstand = bahnSteigKantes.map [
+				pzb.getBahnsteigAbstand(it)
+			].flatten
+			// M: Sskp.Ina.Abstand_GM_2000_Bahnsteig.Abstand_GM_2000_Bahnsteig_Anfang
+			fillConditional(
+				instance,
+				cols.getColumn(Abstand_GM_2000_Bahnsteig_Anfang),
+				pzb,
+				[!bahnSteigKantes.empty],
+				[
+					bahnSteigAbstand.max.toTableInteger
+				]
+			)
+
+			// N: Sskp.Ina.Abstand_GM_2000_Bahnsteig.Abstand_GM_2000_Bahnsteig_Ende
+			fillConditional(
+				instance,
+				cols.getColumn(Abstand_GM_2000_Bahnsteig_Ende),
+				pzb,
+				[!bahnSteigKantes.empty],
+				[
+					bahnSteigAbstand.min.toTableInteger
+				]
+			)
+
+			// O: Sskp.Ina.H-Tafel_Abstand
+			fillIterableWithConditional(
+				instance,
+				cols.getColumn(H_Tafel_Abstand),
+				pzb,
+				[
+					PZBZuordnungSignal?.map[IDSignal?.signalRahmen].flatten.map [
+						signalbegriffe
+					].flatten.exists [
+						hasSignalbegriffID(Ne5)
+					]
+				],
+				[
+					PZBZuordnungSignal?.map[IDSignal].map [ signal |
+						getPointsDistance(topGraph, pzb, signal).min
+					].filter[it.doubleValue === 0.0].map [
+						AgateRounding.roundDown(it).toString
+					]
+				],
+				NUMERIC_COMPARATOR,
+				ITERABLE_FILLING_SEPARATOR
+			)
+
+			// P: Sskp.Ina.Abstand_VorsignalWdh_GM_2000
+			fillIterableWithConditional(
+				instance,
+				cols.getColumn(Abstand_vorsignalWdh_GM_2000),
+				pzb,
+				[
+					PZBZuordnungSignal?.map[IDSignal].exists [
+						signalReal?.signalRealAktivSchirm?.signalArt?.wert ===
+							ENUMSignalArt.ENUM_SIGNAL_ART_VORSIGNALWIEDERHOLER
+					]
+				],
+				[
+					PZBZuordnungSignal?.map[IDSignal].map [ signal |
+						getPointsDistance(topGraph, pzb, signal).min
+					].filter[it.doubleValue === 0.0].map [
+						AgateRounding.roundDown(it).toString
+					]
+				],
+				NUMERIC_COMPARATOR,
+				ITERABLE_FILLING_SEPARATOR
+			)
+
+			// Q: Sskp.Ina.Prüfdatum_Wirkbereichsbogen
+			// Fill Attribute exixts first on Model 1.11
+			fill(
+				instance,
+				cols.getColumn(Pruefdatum_Wirkbereichsbogen),
+				pzb,
+				[""]
+			)
+
+		} else {
+			for (var i = 9; i < 15; i++) {
+				fillBlank(instance, i)
+			}
+		}
+
+		if (pzb.PZBElementGUE !== null) {
+			// R: Sskp.Gue.Pruefgeschwindigkeit
+			fill(
+				instance,
+				cols.getColumn(Pruefgeschwindigkeit),
+				pzb,
+				[PZBElementGUE.pruefgeschwindigkeit?.wert.intValue.toString]
+			)
+
+			// S: Sskp.Gue.Pruefzeit
+			fill(
+				instance,
+				cols.getColumn(Pruefzeit),
+				pzb,
+				[PZBElementGUE.pruefzeit?.wert.toTableInteger]
+			)
+
+			// T: Sskp.Gue.Messfehler
+			fill(
+				instance,
+				cols.getColumn(Messfehler),
+				pzb,
+				[PZBElementGUE.messfehler?.wert.translate]
+			)
+
+			// U: Sskp.Gue.Messstrecke
+			fill(
+				instance,
+				cols.getColumn(Messstrecke),
+				pzb,
+				[PZBElementGUE.GUEMessstrecke?.wert.intValue.toString]
+			)
+
+			// V: Sskp.Gue.GUE_Anordnung
+			fill(
+				instance,
+				cols.getColumn(GUE_Anordnung),
+				pzb,
+				[PZBElementGUE.GUEAnordnung?.wert.translate]
+			)
+
+			// W: Sskp.Gue.GUE_Bauart
+			fill(
+				instance,
+				cols.getColumn(GUE_Bauart),
+				pzb,
+				[PZBElementGUE.GUEBauart?.wert.translate]
+			)
+
+			// X: SSkp.Gue.Montageort_Schaltkastens
+			fill(
+				instance,
+				cols.getColumn(Montageort_Schaltkastens),
+				pzb,
+				[
+					IDUnterbringung?.unterbringungAllg?.
+						unterbringungBefestigung?.wert.translate
+				]
+			)
+
+			// Y: Sskp.Gue.Energieversorgung
+			fill(
+				instance,
+				cols.getColumn(Energieversorgung),
+				pzb,
+				[PZBElementGUE.GUEEnergieversorgung?.wert.translate]
+			)
+		} else {
+			for (var i = 15; i < 23; i++) {
+				fillBlank(instance, i)
+			}
+		}
+
+		// Z: Sskp.Bemerkung
+		fill(
+			instance,
+			cols.getColumn(Bemerkung),
+			pzb,
+			[]
+		)
+
 	}
 
 	private dispatch def String fillBezugsElement(Basis_Objekt object) {
@@ -527,8 +524,8 @@ class SskpTransformator extends AbstractPlanPro2TableModelTransformator {
 	private dispatch def String fillBezugsElement(Signal object) {
 		return object.signalReal.signalFunktion.wert ===
 			ENUMSignalFunktion.ENUM_SIGNAL_FUNKTION_BUE_UEBERWACHUNGSSIGNAL
-			? '''BÜ-K «object?.bezeichnung?.bezeichnungTabelle?.wert»'''
-			: object?.bezeichnung?.bezeichnungTabelle?.wert
+			? '''BÜ-K «object?.bezeichnung?.bezeichnungTabelle?.wert»''' : object?.
+			bezeichnung?.bezeichnungTabelle?.wert
 	}
 
 	private dispatch def String getDistanceSignalTrackSwtich(TopGraph topGraph,
@@ -542,12 +539,12 @@ class SskpTransformator extends AbstractPlanPro2TableModelTransformator {
 			ENUMSignalFunktion.ENUM_SIGNAL_FUNKTION_BUE_UEBERWACHUNGSSIGNAL) {
 			val distance = AgateRounding.roundDown(
 				getPointsDistance(topGraph, pzb, signal).min)
-			val directionSign = topGraph.isInWirkrichtungOfSignal(signal, pzb)
-				? "+"
-				: "-"
-			return distance == 0 ? distance.toString : '''«directionSign»«distance.toString»'''
+			val directionSign = topGraph.
+					isInWirkrichtungOfSignal(signal, pzb) ? "+" : "-"
+			return distance == 0 ? distance.
+				toString : '''«directionSign»«distance.toString»'''
 		}
-		
+
 		val bueSpezifischesSignal = signal.container.BUESpezifischesSignal.
 			filter [
 				IDSignal === signal
@@ -556,13 +553,13 @@ class SskpTransformator extends AbstractPlanPro2TableModelTransformator {
 		if (bueSpezifischesSignal.empty) {
 			return ""
 		}
-		
+
 		val bueKantens = signal.container.BUEKante.filter [ kante |
 			bueSpezifischesSignal.map[IDBUEAnlage].exists [
 				it === kante.IDBUEAnlage
 			]
 		]
-		
+
 		if (bueKantens.empty) {
 			return ""
 		}

--- a/java/bundles/org.eclipse.set.feature.table.pt1/src/org/eclipse/set/feature/table/pt1/sskt/SsktTransformationService.java
+++ b/java/bundles/org.eclipse.set.feature.table.pt1/src/org/eclipse/set/feature/table/pt1/sskt/SsktTransformationService.java
@@ -12,16 +12,20 @@ import static org.eclipse.nebula.widgets.nattable.sort.SortDirectionEnum.ASC;
 import static org.eclipse.set.utils.table.sorting.ComparatorBuilder.CellComparatorType.MIXED_STRING;
 
 import java.util.Comparator;
+import java.util.List;
 
 import org.eclipse.set.core.services.enumtranslation.EnumTranslationService;
 import org.eclipse.set.feature.table.PlanPro2TableTransformationService;
 import org.eclipse.set.feature.table.pt1.AbstractPlanPro2TableModelTransformator;
 import org.eclipse.set.feature.table.pt1.AbstractPlanPro2TableTransformationService;
 import org.eclipse.set.feature.table.pt1.messages.Messages;
+import org.eclipse.set.model.tablemodel.ColumnDescriptor;
 import org.eclipse.set.model.tablemodel.RowGroup;
+import org.eclipse.set.model.tablemodel.RowMergeMode;
 import org.eclipse.set.ppmodel.extensions.utils.TableNameInfo;
 import org.eclipse.set.toolboxmodel.Ansteuerung_Element.Technik_Standort;
 import org.eclipse.set.toolboxmodel.Bedienung.Bedien_Standort;
+import org.eclipse.set.utils.table.ColumnDescriptorModelBuilder;
 import org.eclipse.set.utils.table.sorting.TableRowGroupComparator;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -66,5 +70,23 @@ public class SsktTransformationService
 	@Override
 	protected String getTableHeading() {
 		return messages.SsktTableView_Heading;
+	}
+
+	@Override
+	public ColumnDescriptor fillHeaderDescriptions(
+			final ColumnDescriptorModelBuilder builder) {
+		final ColumnDescriptor cd = super.fillHeaderDescriptions(builder);
+		// Merge all columns except M to O
+		cd.setMergeCommonValues(RowMergeMode.ENABLED);
+		List.of(SsktColumns.IP_Teilsystem_Art, //
+				SsktColumns.Teilsystem_TS_Blau, //
+				SsktColumns.Teilsystem_TS_Grau)
+				.forEach(it -> cols.forEach(col -> {
+					if (it.equals(col.getColumnPosition())) {
+						col.setMergeCommonValues(RowMergeMode.DISABLED);
+					}
+				}));
+
+		return cd;
 	}
 }

--- a/java/bundles/org.eclipse.set.model.tablemodel.edit/plugin.properties
+++ b/java/bundles/org.eclipse.set.model.tablemodel.edit/plugin.properties
@@ -686,3 +686,6 @@ _UI_MultiColorContent_stringFormat_feature = String Format
 _UI_CompareCellContent_unchangedValue_feature = Unchanged Value
 _UI_CellContent_separator_feature = Separator
 _UI_TableRow_rowIndex_feature = Row Index
+_UI_RowMergeMode_DEFAULT_literal = DEFAULT
+_UI_RowMergeMode_ENABLED_literal = ENABLED
+_UI_RowMergeMode_DISABLED_literal = DISABLED

--- a/java/bundles/org.eclipse.set.model.tablemodel.edit/src/org/eclipse/set/model/tablemodel/provider/ColumnDescriptorItemProvider.java
+++ b/java/bundles/org.eclipse.set.model.tablemodel.edit/src/org/eclipse/set/model/tablemodel/provider/ColumnDescriptorItemProvider.java
@@ -273,7 +273,7 @@ public class ColumnDescriptorItemProvider
 				 true,
 				 false,
 				 false,
-				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
 				 null,
 				 null));
 	}

--- a/java/bundles/org.eclipse.set.model.tablemodel.edit/src/org/eclipse/set/model/tablemodel/provider/TablemodelEditPlugin.java
+++ b/java/bundles/org.eclipse.set.model.tablemodel.edit/src/org/eclipse/set/model/tablemodel/provider/TablemodelEditPlugin.java
@@ -27,8 +27,8 @@ public final class TablemodelEditPlugin extends EMFPlugin {
 	 */
 	public static class Implementation extends EclipsePlugin {
 		/**
-		 * Creates an instance. <!-- begin-user-doc --> <!-- end-user-doc -->
-		 * 
+		 * Creates an instance.
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
 		 * @generated
 		 */
 		public Implementation() {
@@ -57,9 +57,9 @@ public final class TablemodelEditPlugin extends EMFPlugin {
 	private static Implementation plugin;
 
 	/**
-	 * Returns the singleton instance of the Eclipse plugin. <!-- begin-user-doc
+	 * Returns the singleton instance of the Eclipse plugin.
+	 * <!-- begin-user-doc
 	 * --> <!-- end-user-doc -->
-	 * 
 	 * @return the singleton instance.
 	 * @generated
 	 */
@@ -68,18 +68,21 @@ public final class TablemodelEditPlugin extends EMFPlugin {
 	}
 
 	/**
-	 * Create the instance. <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 * Create the instance.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	public TablemodelEditPlugin() {
-		super(new ResourceLocator[] { PlanProEditPlugin.INSTANCE, });
+		super
+		  (new ResourceLocator [] {
+		     PlanProEditPlugin.INSTANCE,
+		   });
 	}
 
 	/**
-	 * Returns the singleton instance of the Eclipse plugin. <!-- begin-user-doc
+	 * Returns the singleton instance of the Eclipse plugin.
+	 * <!-- begin-user-doc
 	 * --> <!-- end-user-doc -->
-	 * 
 	 * @return the singleton instance.
 	 * @generated
 	 */

--- a/java/bundles/org.eclipse.set.model.tablemodel/model/tablemodel.ecore
+++ b/java/bundles/org.eclipse.set.model.tablemodel/model/tablemodel.ecore
@@ -67,7 +67,8 @@
         <details key="documentation" value="The height of the row in cm."/>
       </eAnnotations>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="mergeCommonValues" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="mergeCommonValues" eType="#//RowMergeMode"
+        defaultValueLiteral="DEFAULT"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="columnPosition" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="The position of this column"/>
@@ -198,5 +199,10 @@
   <eClassifiers xsi:type="ecore:EClass" name="MultiColorContent">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="multiColorValue" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="stringFormat" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="RowMergeMode">
+    <eLiterals name="DEFAULT" literal="DEFAULT"/>
+    <eLiterals name="ENABLED" value="1" literal="ENABLED"/>
+    <eLiterals name="DISABLED" value="2" literal="DISABLED"/>
   </eClassifiers>
 </ecore:EPackage>

--- a/java/bundles/org.eclipse.set.model.tablemodel/model/tablemodel.genmodel
+++ b/java/bundles/org.eclipse.set.model.tablemodel/model/tablemodel.genmodel
@@ -13,6 +13,11 @@
       <genEnumLiterals ecoreEnumLiteral="tablemodel.ecore#//ColumnWidthMode/WIDTH_CM"/>
       <genEnumLiterals ecoreEnumLiteral="tablemodel.ecore#//ColumnWidthMode/WIDTH_PERCENT"/>
     </genEnums>
+    <genEnums typeSafeEnumCompatible="false" ecoreEnum="tablemodel.ecore#//RowMergeMode">
+      <genEnumLiterals ecoreEnumLiteral="tablemodel.ecore#//RowMergeMode/DEFAULT"/>
+      <genEnumLiterals ecoreEnumLiteral="tablemodel.ecore#//RowMergeMode/ENABLED"/>
+      <genEnumLiterals ecoreEnumLiteral="tablemodel.ecore#//RowMergeMode/DISABLED"/>
+    </genEnums>
     <genClasses ecoreClass="tablemodel.ecore#//Table">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference tablemodel.ecore#//Table/columndescriptors"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference tablemodel.ecore#//Table/tablecontent"/>

--- a/java/bundles/org.eclipse.set.model.tablemodel/src/org/eclipse/set/model/tablemodel/ColumnDescriptor.java
+++ b/java/bundles/org.eclipse.set.model.tablemodel/src/org/eclipse/set/model/tablemodel/ColumnDescriptor.java
@@ -33,7 +33,7 @@ import org.eclipse.emf.ecore.EObject;
  *   <li>{@link org.eclipse.set.model.tablemodel.ColumnDescriptor#isUnit <em>Unit</em>}</li>
  *   <li>{@link org.eclipse.set.model.tablemodel.ColumnDescriptor#getParent <em>Parent</em>}</li>
  *   <li>{@link org.eclipse.set.model.tablemodel.ColumnDescriptor#getHeight <em>Height</em>}</li>
- *   <li>{@link org.eclipse.set.model.tablemodel.ColumnDescriptor#isMergeCommonValues <em>Merge Common Values</em>}</li>
+ *   <li>{@link org.eclipse.set.model.tablemodel.ColumnDescriptor#getMergeCommonValues <em>Merge Common Values</em>}</li>
  *   <li>{@link org.eclipse.set.model.tablemodel.ColumnDescriptor#getColumnPosition <em>Column Position</em>}</li>
  * </ul>
  *
@@ -239,25 +239,29 @@ public interface ColumnDescriptor extends EObject {
 
 	/**
 	 * Returns the value of the '<em><b>Merge Common Values</b></em>' attribute.
+	 * The default value is <code>"DEFAULT"</code>.
+	 * The literals are from the enumeration {@link org.eclipse.set.model.tablemodel.RowMergeMode}.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Merge Common Values</em>' attribute.
-	 * @see #setMergeCommonValues(boolean)
+	 * @see org.eclipse.set.model.tablemodel.RowMergeMode
+	 * @see #setMergeCommonValues(RowMergeMode)
 	 * @see org.eclipse.set.model.tablemodel.TablemodelPackage#getColumnDescriptor_MergeCommonValues()
-	 * @model
+	 * @model default="DEFAULT"
 	 * @generated
 	 */
-	boolean isMergeCommonValues();
+	RowMergeMode getMergeCommonValues();
 
 	/**
-	 * Sets the value of the '{@link org.eclipse.set.model.tablemodel.ColumnDescriptor#isMergeCommonValues <em>Merge Common Values</em>}' attribute.
+	 * Sets the value of the '{@link org.eclipse.set.model.tablemodel.ColumnDescriptor#getMergeCommonValues <em>Merge Common Values</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @param value the new value of the '<em>Merge Common Values</em>' attribute.
-	 * @see #isMergeCommonValues()
+	 * @see org.eclipse.set.model.tablemodel.RowMergeMode
+	 * @see #getMergeCommonValues()
 	 * @generated
 	 */
-	void setMergeCommonValues(boolean value);
+	void setMergeCommonValues(RowMergeMode value);
 
 	/**
 	 * Returns the value of the '<em><b>Column Position</b></em>' attribute.

--- a/java/bundles/org.eclipse.set.model.tablemodel/src/org/eclipse/set/model/tablemodel/RowMergeMode.java
+++ b/java/bundles/org.eclipse.set.model.tablemodel/src/org/eclipse/set/model/tablemodel/RowMergeMode.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright (c) 2022 DB Netz AG and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+package org.eclipse.set.model.tablemodel;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.emf.common.util.Enumerator;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the literals of the enumeration '<em><b>Row Merge Mode</b></em>',
+ * and utility methods for working with them.
+ * <!-- end-user-doc -->
+ * @see org.eclipse.set.model.tablemodel.TablemodelPackage#getRowMergeMode()
+ * @model
+ * @generated
+ */
+public enum RowMergeMode implements Enumerator {
+	/**
+	 * The '<em><b>DEFAULT</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #DEFAULT_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	DEFAULT(0, "DEFAULT", "DEFAULT"),
+
+	/**
+	 * The '<em><b>ENABLED</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #ENABLED_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	ENABLED(1, "ENABLED", "ENABLED"),
+
+	/**
+	 * The '<em><b>DISABLED</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #DISABLED_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	DISABLED(2, "DISABLED", "DISABLED");
+
+	/**
+	 * The '<em><b>DEFAULT</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #DEFAULT
+	 * @model
+	 * @generated
+	 * @ordered
+	 */
+	public static final int DEFAULT_VALUE = 0;
+
+	/**
+	 * The '<em><b>ENABLED</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #ENABLED
+	 * @model
+	 * @generated
+	 * @ordered
+	 */
+	public static final int ENABLED_VALUE = 1;
+
+	/**
+	 * The '<em><b>DISABLED</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #DISABLED
+	 * @model
+	 * @generated
+	 * @ordered
+	 */
+	public static final int DISABLED_VALUE = 2;
+
+	/**
+	 * An array of all the '<em><b>Row Merge Mode</b></em>' enumerators.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private static final RowMergeMode[] VALUES_ARRAY =
+		new RowMergeMode[] {
+			DEFAULT,
+			ENABLED,
+			DISABLED,
+		};
+
+	/**
+	 * A public read-only list of all the '<em><b>Row Merge Mode</b></em>' enumerators.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static final List<RowMergeMode> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
+
+	/**
+	 * Returns the '<em><b>Row Merge Mode</b></em>' literal with the specified literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param literal the literal.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static RowMergeMode get(String literal) {
+		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
+			RowMergeMode result = VALUES_ARRAY[i];
+			if (result.toString().equals(literal)) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the '<em><b>Row Merge Mode</b></em>' literal with the specified name.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param name the name.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static RowMergeMode getByName(String name) {
+		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
+			RowMergeMode result = VALUES_ARRAY[i];
+			if (result.getName().equals(name)) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the '<em><b>Row Merge Mode</b></em>' literal with the specified integer value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the integer value.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static RowMergeMode get(int value) {
+		switch (value) {
+			case DEFAULT_VALUE: return DEFAULT;
+			case ENABLED_VALUE: return ENABLED;
+			case DISABLED_VALUE: return DISABLED;
+		}
+		return null;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final int value;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final String name;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final String literal;
+
+	/**
+	 * Only this class can construct instances.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private RowMergeMode(int value, String name, String literal) {
+		this.value = value;
+		this.name = name;
+		this.literal = literal;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public int getValue() {
+	  return value;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String getName() {
+	  return name;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String getLiteral() {
+	  return literal;
+	}
+
+	/**
+	 * Returns the literal value of the enumerator, which is its string representation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		return literal;
+	}
+	
+} //RowMergeMode

--- a/java/bundles/org.eclipse.set.model.tablemodel/src/org/eclipse/set/model/tablemodel/TablemodelPackage.java
+++ b/java/bundles/org.eclipse.set.model.tablemodel/src/org/eclipse/set/model/tablemodel/TablemodelPackage.java
@@ -746,6 +746,17 @@ public interface TablemodelPackage extends EPackage {
 
 
 	/**
+	 * The meta object id for the '{@link org.eclipse.set.model.tablemodel.RowMergeMode <em>Row Merge Mode</em>}' enum.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.set.model.tablemodel.RowMergeMode
+	 * @see org.eclipse.set.model.tablemodel.impl.TablemodelPackageImpl#getRowMergeMode()
+	 * @generated
+	 */
+	int ROW_MERGE_MODE = 14;
+
+
+	/**
 	 * Returns the meta object for class '{@link org.eclipse.set.model.tablemodel.Table <em>Table</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -876,11 +887,11 @@ public interface TablemodelPackage extends EPackage {
 	EAttribute getColumnDescriptor_Height();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.set.model.tablemodel.ColumnDescriptor#isMergeCommonValues <em>Merge Common Values</em>}'.
+	 * Returns the meta object for the attribute '{@link org.eclipse.set.model.tablemodel.ColumnDescriptor#getMergeCommonValues <em>Merge Common Values</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the meta object for the attribute '<em>Merge Common Values</em>'.
-	 * @see org.eclipse.set.model.tablemodel.ColumnDescriptor#isMergeCommonValues()
+	 * @see org.eclipse.set.model.tablemodel.ColumnDescriptor#getMergeCommonValues()
 	 * @see #getColumnDescriptor()
 	 * @generated
 	 */
@@ -1225,6 +1236,16 @@ public interface TablemodelPackage extends EPackage {
 	 * @generated
 	 */
 	EEnum getColumnWidthMode();
+
+	/**
+	 * Returns the meta object for enum '{@link org.eclipse.set.model.tablemodel.RowMergeMode <em>Row Merge Mode</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for enum '<em>Row Merge Mode</em>'.
+	 * @see org.eclipse.set.model.tablemodel.RowMergeMode
+	 * @generated
+	 */
+	EEnum getRowMergeMode();
 
 	/**
 	 * Returns the factory that creates the instances of the model.
@@ -1636,6 +1657,16 @@ public interface TablemodelPackage extends EPackage {
 		 * @generated
 		 */
 		EEnum COLUMN_WIDTH_MODE = eINSTANCE.getColumnWidthMode();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.set.model.tablemodel.RowMergeMode <em>Row Merge Mode</em>}' enum.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.set.model.tablemodel.RowMergeMode
+		 * @see org.eclipse.set.model.tablemodel.impl.TablemodelPackageImpl#getRowMergeMode()
+		 * @generated
+		 */
+		EEnum ROW_MERGE_MODE = eINSTANCE.getRowMergeMode();
 
 	}
 

--- a/java/bundles/org.eclipse.set.model.tablemodel/src/org/eclipse/set/model/tablemodel/impl/ColumnDescriptorImpl.java
+++ b/java/bundles/org.eclipse.set.model.tablemodel/src/org/eclipse/set/model/tablemodel/impl/ColumnDescriptorImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
 
 import org.eclipse.set.model.tablemodel.ColumnDescriptor;
 import org.eclipse.set.model.tablemodel.ColumnWidthMode;
+import org.eclipse.set.model.tablemodel.RowMergeMode;
 import org.eclipse.set.model.tablemodel.TablemodelPackage;
 
 /**
@@ -44,7 +45,7 @@ import org.eclipse.set.model.tablemodel.TablemodelPackage;
  *   <li>{@link org.eclipse.set.model.tablemodel.impl.ColumnDescriptorImpl#isUnit <em>Unit</em>}</li>
  *   <li>{@link org.eclipse.set.model.tablemodel.impl.ColumnDescriptorImpl#getParent <em>Parent</em>}</li>
  *   <li>{@link org.eclipse.set.model.tablemodel.impl.ColumnDescriptorImpl#getHeight <em>Height</em>}</li>
- *   <li>{@link org.eclipse.set.model.tablemodel.impl.ColumnDescriptorImpl#isMergeCommonValues <em>Merge Common Values</em>}</li>
+ *   <li>{@link org.eclipse.set.model.tablemodel.impl.ColumnDescriptorImpl#getMergeCommonValues <em>Merge Common Values</em>}</li>
  *   <li>{@link org.eclipse.set.model.tablemodel.impl.ColumnDescriptorImpl#getColumnPosition <em>Column Position</em>}</li>
  * </ul>
  *
@@ -192,24 +193,24 @@ public class ColumnDescriptorImpl extends MinimalEObjectImpl.Container implement
 	protected double height = HEIGHT_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #isMergeCommonValues() <em>Merge Common Values</em>}' attribute.
+	 * The default value of the '{@link #getMergeCommonValues() <em>Merge Common Values</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #isMergeCommonValues()
+	 * @see #getMergeCommonValues()
 	 * @generated
 	 * @ordered
 	 */
-	protected static final boolean MERGE_COMMON_VALUES_EDEFAULT = false;
+	protected static final RowMergeMode MERGE_COMMON_VALUES_EDEFAULT = RowMergeMode.DEFAULT;
 
 	/**
-	 * The cached value of the '{@link #isMergeCommonValues() <em>Merge Common Values</em>}' attribute.
+	 * The cached value of the '{@link #getMergeCommonValues() <em>Merge Common Values</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #isMergeCommonValues()
+	 * @see #getMergeCommonValues()
 	 * @generated
 	 * @ordered
 	 */
-	protected boolean mergeCommonValues = MERGE_COMMON_VALUES_EDEFAULT;
+	protected RowMergeMode mergeCommonValues = MERGE_COMMON_VALUES_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #getColumnPosition() <em>Column Position</em>}' attribute.
@@ -469,7 +470,7 @@ public class ColumnDescriptorImpl extends MinimalEObjectImpl.Container implement
 	 * @generated
 	 */
 	@Override
-	public boolean isMergeCommonValues() {
+	public RowMergeMode getMergeCommonValues() {
 		return mergeCommonValues;
 	}
 
@@ -479,9 +480,9 @@ public class ColumnDescriptorImpl extends MinimalEObjectImpl.Container implement
 	 * @generated
 	 */
 	@Override
-	public void setMergeCommonValues(boolean newMergeCommonValues) {
-		boolean oldMergeCommonValues = mergeCommonValues;
-		mergeCommonValues = newMergeCommonValues;
+	public void setMergeCommonValues(RowMergeMode newMergeCommonValues) {
+		RowMergeMode oldMergeCommonValues = mergeCommonValues;
+		mergeCommonValues = newMergeCommonValues == null ? MERGE_COMMON_VALUES_EDEFAULT : newMergeCommonValues;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, TablemodelPackage.COLUMN_DESCRIPTOR__MERGE_COMMON_VALUES, oldMergeCommonValues, mergeCommonValues));
 	}
@@ -570,7 +571,7 @@ public class ColumnDescriptorImpl extends MinimalEObjectImpl.Container implement
 			case TablemodelPackage.COLUMN_DESCRIPTOR__HEIGHT:
 				return getHeight();
 			case TablemodelPackage.COLUMN_DESCRIPTOR__MERGE_COMMON_VALUES:
-				return isMergeCommonValues();
+				return getMergeCommonValues();
 			case TablemodelPackage.COLUMN_DESCRIPTOR__COLUMN_POSITION:
 				return getColumnPosition();
 		}
@@ -612,7 +613,7 @@ public class ColumnDescriptorImpl extends MinimalEObjectImpl.Container implement
 				setHeight((Double)newValue);
 				return;
 			case TablemodelPackage.COLUMN_DESCRIPTOR__MERGE_COMMON_VALUES:
-				setMergeCommonValues((Boolean)newValue);
+				setMergeCommonValues((RowMergeMode)newValue);
 				return;
 			case TablemodelPackage.COLUMN_DESCRIPTOR__COLUMN_POSITION:
 				setColumnPosition((String)newValue);

--- a/java/bundles/org.eclipse.set.model.tablemodel/src/org/eclipse/set/model/tablemodel/impl/TablemodelFactoryImpl.java
+++ b/java/bundles/org.eclipse.set.model.tablemodel/src/org/eclipse/set/model/tablemodel/impl/TablemodelFactoryImpl.java
@@ -90,6 +90,8 @@ public class TablemodelFactoryImpl extends EFactoryImpl implements TablemodelFac
 		switch (eDataType.getClassifierID()) {
 			case TablemodelPackage.COLUMN_WIDTH_MODE:
 				return createColumnWidthModeFromString(eDataType, initialValue);
+			case TablemodelPackage.ROW_MERGE_MODE:
+				return createRowMergeModeFromString(eDataType, initialValue);
 			default:
 				throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
 		}
@@ -105,6 +107,8 @@ public class TablemodelFactoryImpl extends EFactoryImpl implements TablemodelFac
 		switch (eDataType.getClassifierID()) {
 			case TablemodelPackage.COLUMN_WIDTH_MODE:
 				return convertColumnWidthModeToString(eDataType, instanceValue);
+			case TablemodelPackage.ROW_MERGE_MODE:
+				return convertRowMergeModeToString(eDataType, instanceValue);
 			default:
 				throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
 		}
@@ -259,6 +263,26 @@ public class TablemodelFactoryImpl extends EFactoryImpl implements TablemodelFac
 	 * @generated
 	 */
 	public String convertColumnWidthModeToString(EDataType eDataType, Object instanceValue) {
+		return instanceValue == null ? null : instanceValue.toString();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public RowMergeMode createRowMergeModeFromString(EDataType eDataType, String initialValue) {
+		RowMergeMode result = RowMergeMode.get(initialValue);
+		if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
+		return result;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String convertRowMergeModeToString(EDataType eDataType, Object instanceValue) {
 		return instanceValue == null ? null : instanceValue.toString();
 	}
 

--- a/java/bundles/org.eclipse.set.model.tablemodel/src/org/eclipse/set/model/tablemodel/impl/TablemodelPackageImpl.java
+++ b/java/bundles/org.eclipse.set.model.tablemodel/src/org/eclipse/set/model/tablemodel/impl/TablemodelPackageImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.set.model.tablemodel.Footnote;
 import org.eclipse.set.model.tablemodel.MultiColorCellContent;
 import org.eclipse.set.model.tablemodel.MultiColorContent;
 import org.eclipse.set.model.tablemodel.RowGroup;
+import org.eclipse.set.model.tablemodel.RowMergeMode;
 import org.eclipse.set.model.tablemodel.StringCellContent;
 import org.eclipse.set.model.tablemodel.Table;
 import org.eclipse.set.model.tablemodel.TableCell;
@@ -144,6 +145,13 @@ public class TablemodelPackageImpl extends EPackageImpl implements TablemodelPac
 	 * @generated
 	 */
 	private EEnum columnWidthModeEEnum = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EEnum rowMergeModeEEnum = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
@@ -671,6 +679,16 @@ public class TablemodelPackageImpl extends EPackageImpl implements TablemodelPac
 	 * @generated
 	 */
 	@Override
+	public EEnum getRowMergeMode() {
+		return rowMergeModeEEnum;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public TablemodelFactory getTablemodelFactory() {
 		return (TablemodelFactory)getEFactoryInstance();
 	}
@@ -753,6 +771,7 @@ public class TablemodelPackageImpl extends EPackageImpl implements TablemodelPac
 
 		// Create enums
 		columnWidthModeEEnum = createEEnum(COLUMN_WIDTH_MODE);
+		rowMergeModeEEnum = createEEnum(ROW_MERGE_MODE);
 	}
 
 	/**
@@ -804,7 +823,7 @@ public class TablemodelPackageImpl extends EPackageImpl implements TablemodelPac
 		initEAttribute(getColumnDescriptor_Unit(), ecorePackage.getEBoolean(), "unit", null, 1, 1, ColumnDescriptor.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getColumnDescriptor_Parent(), this.getColumnDescriptor(), this.getColumnDescriptor_Children(), "parent", null, 0, 1, ColumnDescriptor.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getColumnDescriptor_Height(), ecorePackage.getEDouble(), "height", null, 0, 1, ColumnDescriptor.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEAttribute(getColumnDescriptor_MergeCommonValues(), ecorePackage.getEBoolean(), "mergeCommonValues", null, 0, 1, ColumnDescriptor.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getColumnDescriptor_MergeCommonValues(), this.getRowMergeMode(), "mergeCommonValues", "DEFAULT", 0, 1, ColumnDescriptor.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getColumnDescriptor_ColumnPosition(), ecorePackage.getEString(), "columnPosition", null, 0, 1, ColumnDescriptor.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(tableContentEClass, TableContent.class, "TableContent", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
@@ -852,6 +871,11 @@ public class TablemodelPackageImpl extends EPackageImpl implements TablemodelPac
 		initEEnum(columnWidthModeEEnum, ColumnWidthMode.class, "ColumnWidthMode");
 		addEEnumLiteral(columnWidthModeEEnum, ColumnWidthMode.WIDTH_CM);
 		addEEnumLiteral(columnWidthModeEEnum, ColumnWidthMode.WIDTH_PERCENT);
+
+		initEEnum(rowMergeModeEEnum, RowMergeMode.class, "RowMergeMode");
+		addEEnumLiteral(rowMergeModeEEnum, RowMergeMode.DEFAULT);
+		addEEnumLiteral(rowMergeModeEEnum, RowMergeMode.ENABLED);
+		addEEnumLiteral(rowMergeModeEEnum, RowMergeMode.DISABLED);
 
 		// Create resource
 		createResource(eNS_URI);

--- a/java/bundles/org.eclipse.set.utils.table/src/org/eclipse/set/utils/table/TableSpanUtils.java
+++ b/java/bundles/org.eclipse.set.utils.table/src/org/eclipse/set/utils/table/TableSpanUtils.java
@@ -11,6 +11,7 @@ package org.eclipse.set.utils.table;
 import java.util.List;
 
 import org.eclipse.set.model.tablemodel.ColumnDescriptor;
+import org.eclipse.set.model.tablemodel.RowMergeMode;
 import org.eclipse.set.model.tablemodel.TableRow;
 import org.eclipse.set.model.tablemodel.extensions.TableRowExtensions;
 
@@ -83,8 +84,12 @@ public class TableSpanUtils {
 		// And contain the same value
 		final String valueA = TableRowExtensions.getPlainStringValue(rowA,
 				column);
-		final String valueB = TableRowExtensions.getPlainStringValue(rowA,
+		final String valueB = TableRowExtensions.getPlainStringValue(rowB,
 				column);
+
+		if (valueA == null) {
+			return valueB == null;
+		}
 		return valueA.equals(valueB);
 	}
 
@@ -104,10 +109,11 @@ public class TableSpanUtils {
 			if (cd == null) {
 				return false;
 			}
-			if (cd.isMergeCommonValues()) {
-				return true;
+			if (cd.getMergeCommonValues() == RowMergeMode.DEFAULT) {
+				cd = cd.getParent();
+				continue;
 			}
-			cd = cd.getParent();
+			return cd.getMergeCommonValues() == RowMergeMode.ENABLED;
 		}
 	}
 }


### PR DESCRIPTION
Also makes setting row group modes more explicit with Enabled/Disabled/Inherit (Default), rather than just Enabling or Defaulting.

Also reapplies grouping for Sskt (we lost that when moving to Excel as primary column info source)