### PR TITLE
Redurce nil test severity to warning

### DIFF
--- a/java/bundles/org.eclipse.set.feature.validation/src/org/eclipse/set/feature/validation/niltest/NilTest.xtend
+++ b/java/bundles/org.eclipse.set.feature.validation/src/org/eclipse/set/feature/validation/niltest/NilTest.xtend
@@ -101,7 +101,7 @@ class NilTest extends AbstractCustomValidator {
 		val it = new CustomValidationProblemImpl
 		lineNumber = node.lineNumber
 		message = messages.NilTestProblem_Message
-		severity = ValidationSeverity.ERROR
+		severity = ValidationSeverity.WARNING
 		type = validationType
 		objectArt = node.objectType
 		objectScope = node.objectScope


### PR DESCRIPTION
An error is too strict, as a nil-filling may be valid depending on the project state. 