### PR TITLE
Fix empty pages being generated for ssks pdf export

### DIFF
--- a/java/bundles/org.eclipse.set.feature/rootdir/data/export/pdf/multipage_layout.xsl
+++ b/java/bundles/org.eclipse.set.feature/rootdir/data/export/pdf/multipage_layout.xsl
@@ -25,7 +25,7 @@
                 </fo:repeatable-page-master-alternatives>
             </fo:page-sequence-master>
         </fo:layout-master-set>
-        <fo:page-sequence master-reference="table-master-a">
+        <fo:page-sequence force-page-count="no-force" master-reference="table-master-a">
             <fo:static-content flow-name="folding-mark-region">
                 <xsl:call-template name="FoldingMarksTop"/>
                 <xsl:call-template name="WaterMark"/>
@@ -40,7 +40,7 @@
                 <xsl:apply-templates />
             </fo:flow>
         </fo:page-sequence>
-        <fo:page-sequence master-reference="page-sequence-master-b" initial-page-number="1">
+        <fo:page-sequence force-page-count="no-force" master-reference="page-sequence-master-b" initial-page-number="1">
             <fo:static-content flow-name="folding-mark-region">
                 <xsl:call-template name="FoldingMarksTop"/>
                 <xsl:call-template name="WaterMark"/>


### PR DESCRIPTION
By default `force-page-count` is set to `auto`. Per the docs this results in "Force the last page in this page-sequence to be an [..] even-page if the initial-page-number of the next page-sequence is odd. " for the first halves of each table as the the initial page defaults to 1. 

Thus if we have three pages for the first (left) half of the tables, the right side would start at 4. However the sequence for the left side must end on an even number, hence an empty page 4 is added to start the right side at 5. 

As a solution we disable the even/odd page number forcing entirely.

Note that this not only affects the Ssks, but essentially all two-page tables with an odd number of pages.
