### PR TITLE
Fix incorrect content type for hugo views

### DIFF
--- a/web/hugothemes/themes/kraiklyn/layouts/partials/head.html
+++ b/web/hugothemes/themes/kraiklyn/layouts/partials/head.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"{{with .Site.LanguageCode}} xml:lang="{{.}}" lang="{{.}}"{{end}}>
+<html {{with .Site.LanguageCode}} xml:lang="{{.}}" lang="{{.}}"{{end}}>
 <head>
   {{ hugo.Generator }}
 


### PR DESCRIPTION
We do not use XHTML there.