### PR TITLE
Disable automatic fill by craete new Projekt

### DIFF
--- a/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/files/ToolboxFile.java
+++ b/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/files/ToolboxFile.java
@@ -197,6 +197,11 @@ public interface ToolboxFile {
 	void setXMLDocument(String docName, Document doc);
 
 	/**
+	 * Remove all storaged XML Document
+	 */
+	void clearXMLDocument();
+
+	/**
 	 * @return whether the toolbox file (true = detached) or the model (false =
 	 *         embedded) contain the attachments
 	 */

--- a/java/bundles/org.eclipse.set.core/src/org/eclipse/set/core/fileservice/AbstractToolboxFile.java
+++ b/java/bundles/org.eclipse.set.core/src/org/eclipse/set/core/fileservice/AbstractToolboxFile.java
@@ -39,7 +39,7 @@ public abstract class AbstractToolboxFile implements ToolboxFile {
 
 	protected static final String ENCODING = StandardCharsets.UTF_8.name();
 
-	private final HashMap<String, Document> domDocument = new HashMap<>();
+	private HashMap<String, Document> domDocument = new HashMap<>();
 
 	private String md5checksum = null;
 
@@ -53,6 +53,11 @@ public abstract class AbstractToolboxFile implements ToolboxFile {
 	@Override
 	public Document getXMLDocument(final String docName) {
 		return domDocument.get(docName);
+	}
+
+	@Override
+	public void clearXMLDocument() {
+		domDocument = new HashMap<>();
 	}
 
 	@Override

--- a/java/bundles/org.eclipse.set.feature.validation/src/org/eclipse/set/feature/validation/session/ModelSession.java
+++ b/java/bundles/org.eclipse.set.feature.validation/src/org/eclipse/set/feature/validation/session/ModelSession.java
@@ -532,6 +532,7 @@ public class ModelSession implements IModelSession {
 
 	@Override
 	public void refreshValidation() {
+		toolboxFile.clearXMLDocument();
 		init();
 	}
 

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/PlanProSchnittstelleExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/PlanProSchnittstelleExtensions.xtend
@@ -338,7 +338,6 @@ class PlanProSchnittstelleExtensions {
 		val containerZiel = factory.createContainer_AttributeGroup();
 		zustandZiel.setContainer(containerZiel);
 		zustandZiel.fixGuids
-		planPro_Schnittstelle.fillDefaults
 		return planPro_Schnittstelle
 	}
 


### PR DESCRIPTION
- Objectmanagement will only fill Empty Object with nil-value after save. (previously fill by create)
- All storaged XML-Document in Toolboxfile will be remove by save to refresh after save