### PR TITLE
Avoid parsing files for mime detection

### DIFF
--- a/java/bundles/org.eclipse.set.utils/src/org/eclipse/set/utils/FileWebBrowser.java
+++ b/java/bundles/org.eclipse.set.utils/src/org/eclipse/set/utils/FileWebBrowser.java
@@ -176,7 +176,7 @@ public class FileWebBrowser extends WebBrowser implements RequestHandler {
 
 				else {
 					final Path filepath = file.toAbsolutePath();
-					final String contentType = tika.detect(filepath);
+					final String contentType = tika.detect(filepath.toString());
 					serveFile(fileuri, contentType, filepath);
 
 				}


### PR DESCRIPTION
If we pass a `Path` to Tika, the file is partially read to determine mime types. This causes some issues regarding HTML documents incorrectly marked as XHTML and also causes some performance reduction. Thus revert to only using the filename.