### PR TITLE
Adjust naming of table documents

### DIFF
--- a/java/bundles/org.eclipse.set.feature.table.pt1/OSGI-INF/l10n/bundle.properties
+++ b/java/bundles/org.eclipse.set.feature.table.pt1/OSGI-INF/l10n/bundle.properties
@@ -1,147 +1,147 @@
-SsbbTableView_Heading=Bedieneinrichtungstabelle BÜ (Ssbb)
-SsbbDescriptionService_ViewName=Ssbb (Bedieneinrichtungstabelle BÜ)
+SsbbTableView_Heading=Bedieneinrichtungstabelle BÜ – Ssbb
+SsbbDescriptionService_ViewName=Ssbb – Bedieneinrichtungstabelle BÜ
 SsbbDescriptionService_ViewTooltip=Bedieneinrichtungstabelle BÜ
 ToolboxTableNameSsbbLong=Bedieneinrichtungstabelle BÜ
 ToolboxTableNameSsbbPlanningNumber=23/13
 ToolboxTableNameSsbbShort=Ssbb
 
-SskaDescriptionService_ViewName=Sska (Elementansteuertabelle)
+SskaDescriptionService_ViewName=Sska – Elementansteuertabelle
 SskaDescriptionService_ViewTooltip=Elementansteuertabelle
 ToolboxTableNameSskaLong=Elementansteuertabelle
 ToolboxTableNameSskaPlanningNumber=10/03
 ToolboxTableNameSskaShort=Sska
-SskaTableView_Heading=Elementansteuertabelle (Sska)
+SskaTableView_Heading=Elementansteuertabelle – Sska
 
-SskfDescriptionService_ViewName=Sskf (Freimeldetabelle)
+SskfDescriptionService_ViewName=Sskf – Freimeldetabelle
 SskfDescriptionService_ViewTooltip=Freimeldetabelle
 ToolboxTableNameSskfLong=Freimeldetabelle
 ToolboxTableNameSskfPlanningNumber=10/19
 ToolboxTableNameSskfShort=Sskf
-SskfTableView_Heading=Freimeldetabelle (Sskf)
+SskfTableView_Heading=Freimeldetabelle – Sskf
 
-SskgDescriptionService_ViewName=Sskg (Gleisschaltmitteltabelle)
+SskgDescriptionService_ViewName=Sskg – Gleisschaltmitteltabelle
 SskgDescriptionService_ViewTooltip=Gleisschaltmitteltabelle
 ToolboxTableNameSskgLong=Gleisschaltmitteltabelle
 ToolboxTableNameSskgPlanningNumber=10/19
 ToolboxTableNameSskgShort=Sskg
-SskgTableView_Heading=Gleisschaltmitteltabelle (Sskg)
+SskgTableView_Heading=Gleisschaltmitteltabelle – Sskg
 
-SskoDescriptionService_ViewName=Ssko (Schlosstabelle)
+SskoDescriptionService_ViewName=Ssko – Schlosstabelle
 SskoDescriptionService_ViewTooltip=Schlosstabelle
 ToolboxTableNameSskoLong=Schlosstabelle
 ToolboxTableNameSskoPlanningNumber=10/27
 ToolboxTableNameSskoShort=Ssko
-SskoTableView_Heading=Schlosstabelle (Ssko)
+SskoTableView_Heading=Schlosstabelle – Ssko
 
-SskpDescriptionService_ViewName=Sskp (PZB-Tabelle)
+SskpDescriptionService_ViewName=Sskp – PZB-Tabelle
 SskpDescriptionService_ViewTooltip=PZB-Tabelle
 ToolboxTableNameSskpLong=PZB-Tabelle
 ToolboxTableNameSskpPlanningNumber=10/36
 ToolboxTableNameSskpShort=Sskp
-SskpTableView_Heading=PZB-Tabelle (Sskp)
+SskpTableView_Heading=PZB-Tabelle – Sskp
 
-SsksDescriptionService_ViewName=Ssks (Signaltabelle)
+SsksDescriptionService_ViewName=Ssks – Signaltabelle
 SsksDescriptionService_ViewTooltip=Signaltabelle
 ToolboxTableNameSsksLong=Signaltabelle
 ToolboxTableNameSsksPlanningNumber=10/18
 ToolboxTableNameSsksShort=Ssks
-SsksTableView_Heading=Signaltabelle (Ssks)
+SsksTableView_Heading=Signaltabelle – Ssks
 
-SskwDescriptionService_ViewName=Sskw (Weichentabelle)
+SskwDescriptionService_ViewName=Sskw – Weichentabelle
 SskwDescriptionService_ViewTooltip=Weichentabelle
 ToolboxTableNameSskwLong=Weichentabelle
 ToolboxTableNameSskwPlanningNumber=10/23
 ToolboxTableNameSskwShort=Sskw
-SskwTableView_Heading=Weichentabelle (Sskw)
+SskwTableView_Heading=Weichentabelle – Sskw
 
-SslaDescriptionService_ViewName=Ssla (Tabelle der aneinandergereihten Fahrstraßen)
+SslaDescriptionService_ViewName=Ssla – Tabelle der aneinandergereihten Fahrstraßen
 SslaDescriptionService_ViewTooltip=Tabelle der aneinandergereihten Fahrstraßen
 ToolboxTableNameSslaLong=Tabelle der aneinandergereihten Fahrstraßen
 ToolboxTableNameSslaPlanningNumber=10/21
 ToolboxTableNameSslaShort=Ssla
-SslaTableView_Heading=Aneinandergereihte Fahrstraßentabelle (Ssla)
+SslaTableView_Heading=Aneinandergereihte Fahrstraßentabelle – Ssla
 
-SslbDescriptionService_ViewName=Sslb (Streckenblocktabelle)
+SslbDescriptionService_ViewName=Sslb – Streckenblocktabelle
 SslbDescriptionService_ViewTooltip=Streckenblocktabelle
 ToolboxTableNameSslbLong=Streckenblocktabelle
 ToolboxTableNameSslbPlanningNumber=10/33
 ToolboxTableNameSslbShort=Sslb
-SslbTableView_Heading=Streckenblocktabelle (Sslb)
+SslbTableView_Heading=Streckenblocktabelle – Sslb
 
-SsldDescriptionService_ViewName=Ssld (Durchrutschweg- und Gefahrpunkttabelle)
+SsldDescriptionService_ViewName=Ssld – Durchrutschweg- und Gefahrpunkttabelle
 SsldDescriptionService_ViewTooltip=Durchrutschweg- und Gefahrpunkttabelle
 ToolboxTableNameSsldLong=Durchrutschweg- und Gefahrpunkttabelle
 ToolboxTableNameSsldPlanningNumber=10/20
 ToolboxTableNameSsldShort=Ssld
-SsldTableView_Heading=Durchrutschwegtabelle (Ssld)
+SsldTableView_Heading=Durchrutschwegtabelle – Ssld
 
-SslfDescriptionService_ViewName=Sslf (Flankenschutztabelle)
+SslfDescriptionService_ViewName=Sslf – Flankenschutztabelle
 SslfDescriptionService_ViewTooltip=Flankenschutztabelle
 ToolboxTableNameSslfLong=Flankenschutztabelle
 ToolboxTableNameSslfPlanningNumber=10/24
 ToolboxTableNameSslfShort=Sslf
-SslfTableView_Heading=Flankenschutztabelle (Sslf)
+SslfTableView_Heading=Flankenschutztabelle – Sslf
 
-SsliDescriptionService_ViewName=Ssli (Inselgleistabelle)
+SsliDescriptionService_ViewName=Ssli – Inselgleistabelle
 SsliDescriptionService_ViewTooltip=Inselgleistabelle
 ToolboxTableNameSsliLong=Inselgleistabelle
 ToolboxTableNameSsliPlanningNumber=10/21
 ToolboxTableNameSsliShort=Ssli
-Ssli_Heading=Inselgleistabelle (Ssli)
+Ssli_Heading=Inselgleistabelle – Ssli
 
-SslnDescriptionService_ViewName=Ssln (Nahbedientabelle)
+SslnDescriptionService_ViewName=Ssln – Nahbedientabelle
 SslnDescriptionService_ViewTooltip=Nahbedientabelle
 ToolboxTableNameSslnLong=Nahbedientabelle
 ToolboxTableNameSslnPlanningNumber=10/30
 ToolboxTableNameSslnShort=Ssln
-SslnTableView_Heading=Nahbedienungstabelle (Ssln)
+SslnTableView_Heading=Nahbedienungstabelle – Ssln
 
-SslrDescriptionService_ViewName=Sslr (Rangierstraßentabelle)
+SslrDescriptionService_ViewName=Sslr – Rangierstraßentabelle
 SslrDescriptionService_ViewTooltip=Rangierstraßentabelle
 ToolboxTableNameSslrLong=Rangierstraßentabelle
 ToolboxTableNameSslrPlanningNumber=10/22
 ToolboxTableNameSslrShort=Sslr
-Sslr_Heading=Rangierstraßentabelle (Sslr)
+Sslr_Heading=Rangierstraßentabelle – Sslr
 
-SslwDescriptionService_ViewName=Sslw (Zwieschutzweichentabelle)
+SslwDescriptionService_ViewName=Sslw – Zwieschutzweichentabelle
 SslwDescriptionService_ViewTooltip=Zwieschutzweichentabelle
 ToolboxTableNameSslwLong=Zwieschutzweichentabelle
 ToolboxTableNameSslwPlanningNumber=10/25
 ToolboxTableNameSslwShort=Sslw
-SslwTableView_Heading=Zwieschutzweichentabelle (Sslw)
+SslwTableView_Heading=Zwieschutzweichentabelle – Sslw
 
-SslzDescriptionService_ViewName=Sslz (Zugstraßentabelle)
+SslzDescriptionService_ViewName=Sslz – Zugstraßentabelle
 SslzDescriptionService_ViewTooltip=Zugstraßentabelle
 ToolboxTableNameSslzLong=Zugstraßentabelle
 ToolboxTableNameSslzPlanningNumber=10/21
 ToolboxTableNameSslzShort=Sslz
-SslzTableView_Heading=Zugstraßentabelle (Sslz)
+SslzTableView_Heading=Zugstraßentabelle – Sslz
 
-SsvuDescriptionService_ViewName=Ssvu (Übertragungswegtabelle)
+SsvuDescriptionService_ViewName=Ssvu – Übertragungswegtabelle
 SsvuDescriptionService_ViewTooltip=Übertragungswegtabelle
 ToolboxTableNameSsvuLong=Übertragungswegtabelle
 ToolboxTableNameSsvuPlanningNumber=10/39
 ToolboxTableNameSsvuShort=Ssvu
-SsvuTableView_Heading=Übertragungswegtabelle (Ssvu)
+SsvuTableView_Heading=Übertragungswegtabelle – Ssvu
 
-SsitDescriptionService_ViewName=Ssit (Bedieneinrichtungstabelle Stw)
+SsitDescriptionService_ViewName=Ssit – Bedieneinrichtungstabelle Stw
 SsitDescriptionService_ViewTooltip=Bedieneinrichtungstabelle Stw
 ToolboxTableNameSsitLong=Bedieneinrichtungstabelle Stw
 ToolboxTableNameSsitPlanningNumber=10/46
 ToolboxTableNameSsitShort=Ssit
 SsitTableView_Heading=Bedieneinrichtungstabelle Stw
 
-SsktDescriptionService_ViewName=Sskt (Tabelle der Technik- und Bedienstandorte)
+SsktDescriptionService_ViewName=Sskt – Tabelle der Technik- und Bedienstandorte
 SsktDescriptionService_ViewTooltip=Tabelle der Technik- und Bedienstandorte
 ToolboxTableNameSsktLong=Tabelle der Technik- und Bedienstandorte
 ToolboxTableNameSsktPlanningNumber=10/03
 ToolboxTableNameSsktShort=Sskt
-SsktTableView_Heading=Tabelle der Technik- und Bedienstandorte (Sskt)
+SsktTableView_Heading=Tabelle der Technik- und Bedienstandorte – Sskt
 
-SslwDescriptionService_ViewName=Sslw (Zwieschutzweichentabelle)
+SslwDescriptionService_ViewName=Sslw – Zwieschutzweichentabelle
 SslwDescriptionService_ViewTooltip=Zwieschutzweichentabelle
 ToolboxTableNameSslwLong=Zwieschutzweichentabelle
 ToolboxTableNameSslwPlanningNumber=10/25
 ToolboxTableNameSslwShort=Sslw
-SslwTableView_Heading=Zwieschutzweichentabelle (Sslz)
+SslwTableView_Heading=Zwieschutzweichentabelle – Sslz
 

--- a/java/bundles/org.eclipse.set.feature.validation/src/org/eclipse/set/feature/validation/session/ToolboxPathsImpl.java
+++ b/java/bundles/org.eclipse.set.feature.validation/src/org/eclipse/set/feature/validation/session/ToolboxPathsImpl.java
@@ -11,6 +11,7 @@ package org.eclipse.set.feature.validation.session;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.set.basis.ToolboxPaths;
 import org.eclipse.set.basis.constants.ExportType;
 import org.eclipse.set.basis.extensions.PathExtensions;
@@ -67,18 +68,18 @@ public class ToolboxPathsImpl implements ToolboxPaths {
 	private String getTableModel(final String shortcut,
 			final ExportType exportType) {
 		return String.format(TABLE_MODEL_EXPORT_PATTERN,
-				getModelBaseName(exportType), shortcut);
+				getModelBaseName(exportType), StringUtils.capitalize(shortcut));
 	}
 
 	private String getTablePdfExport(final String shortcut,
 			final ExportType exportType) {
 		return String.format(TABLE_PDF_EXPORT_PATTERN,
-				getModelBaseName(exportType), shortcut);
+				getModelBaseName(exportType), StringUtils.capitalize(shortcut));
 	}
 
 	private String getTableXlsxExport(final String shortcut,
 			final ExportType exportType) {
 		return String.format(TABLE_XLSX_EXPORT_PATTERN,
-				getModelBaseName(exportType), shortcut);
+				getModelBaseName(exportType), StringUtils.capitalize(shortcut));
 	}
 }

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/PlanProToTitleboxTransformation.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/PlanProToTitleboxTransformation.xtend
@@ -240,7 +240,7 @@ class PlanProToTitleboxTransformation {
 		return '''
 			«schriftfeld?.bezeichnungAnlage?.wert»
 			«schriftfeld?.bezeichnungUnteranlage?.wert»
-			«tableName?.getLongName ?: "<Planart>"»
+			«tableName?.getFullDisplayName ?: "<Planart>"»
 		'''
 	}
 }

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/TableNameInfo.java
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/TableNameInfo.java
@@ -60,7 +60,7 @@ public class TableNameInfo {
 	 * @return the full display name
 	 */
 	public String getFullDisplayName() {
-		return getShortName() + " (" + getLongName() + ")"; //$NON-NLS-1$ //$NON-NLS-2$
+		return getShortName() + " – " + getLongName(); //$NON-NLS-1$
 	}
 
 	/**


### PR DESCRIPTION
old: [shortname] ([longname])
new: [shortname] – ([longname])
Also capitalizes the shortname in file exports