### PR TITLE
Fix cell comparator not being transitive

### DIFF
--- a/java/bundles/org.eclipse.set.utils.table/src/org/eclipse/set/utils/table/sorting/AbstractCellComparator.xtend
+++ b/java/bundles/org.eclipse.set.utils.table/src/org/eclipse/set/utils/table/sorting/AbstractCellComparator.xtend
@@ -114,10 +114,7 @@ package abstract class AbstractCellComparator implements Comparator<TableCell> {
 		val first = result.get(0)
 		// Either entirely numeric or at most 1 character text
 		if (result.length == 1) {
-			if (isInteger(first))
-				return result.get(0) -> ""
-			else
-				return "" -> result.get(0)
+			return isInteger(first) ? result.get(0) -> "" :  "" -> result.get(0)
 		}
 		// Length: 2 - Either entirely text or mixed
 		val second = result.get(1)

--- a/java/bundles/org.eclipse.set.utils.table/src/org/eclipse/set/utils/table/sorting/AbstractCellComparator.xtend
+++ b/java/bundles/org.eclipse.set.utils.table/src/org/eclipse/set/utils/table/sorting/AbstractCellComparator.xtend
@@ -118,10 +118,7 @@ package abstract class AbstractCellComparator implements Comparator<TableCell> {
 		}
 		// Length: 2 - Either entirely text or mixed
 		val second = result.get(1)
-		if (isInteger(first))
-			return first -> second
-		else
-			return "" -> first + second
+		return isInteger(first) ? first -> second : "" -> first + second
 	}
 
 	def int compareCell(Iterable<String> iterable1,

--- a/java/bundles/org.eclipse.set.utils.table/src/org/eclipse/set/utils/table/sorting/AbstractCellComparator.xtend
+++ b/java/bundles/org.eclipse.set.utils.table/src/org/eclipse/set/utils/table/sorting/AbstractCellComparator.xtend
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2019 DB Netz AG and others.
- *
+ * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -23,13 +23,14 @@ import static extension org.eclipse.set.model.tablemodel.extensions.CellContentE
 package abstract class AbstractCellComparator implements Comparator<TableCell> {
 
 	protected SortDirectionEnum direction
+
 	/**
 	 * @param direction the sort direction
 	 */
 	new(SortDirectionEnum direction) {
 		this.direction = direction
 	}
-	
+
 	override int compare(TableCell cell1, TableCell cell2) {
 		return cell1.content.compareDispatch(cell2.content)
 	}
@@ -62,8 +63,8 @@ package abstract class AbstractCellComparator implements Comparator<TableCell> {
 		CompareCellContent c2
 	) {
 		val newResult = c1.newValue.compareCell(c2.newValue);
-		
-		if (newResult != 0){
+
+		if (newResult != 0) {
 			return newResult
 		}
 		return c1.oldValue.compareCell(c2.oldValue)
@@ -83,30 +84,73 @@ package abstract class AbstractCellComparator implements Comparator<TableCell> {
 		return c1.compareCellContentString.compareCell(c2.value)
 	}
 
-	private def Iterable<String> compareCellContentString(CompareCellContent content) {
-		return #[content.newValue,content.oldValue].flatten.toSet
+	private def Iterable<String> compareCellContentString(
+		CompareCellContent content) {
+		return #[content.newValue, content.oldValue].flatten.toSet
 	}
-	
-	def int compareCell(Iterable<String> iterable1, Iterable<String> iterable2) {
-		// For compare, the separator should be empty
-		val text1 = iterable1.iterableToString("")
-		val text2 = iterable2.iterableToString("")
+
+	/**
+	 * Extract a numeric prefix from a string. For example
+	 * "60P42" -> 60, "P42"
+	 * "60" -> 60, null
+	 * "P42" -> null, "P42"
+	 * "" -> null, ""
+	 *   
+	 */
+	private def Pair<Integer, String> extractNumericPrefix(String text) {
+		if (text === null)
+			return null -> ""
+
+		val result = text.split("((?=\\D)|(?<=\\D))", 2)
+
+		// Either entirely numeric or at most 1 character text
+		if (result.length == 1) {
+			try {
+				// Try reading as int
+				return Integer.parseInt(result.get(0)) -> ""
+			} catch (NumberFormatException e) {
+				// Otherwise it is text
+				return null -> result.get(0)
+			}
+		}
+		// Length: 2 - Either entirely text or mixed
+		val first = result.get(0)
+		val second = result.get(1)
 		try {
-			val number1 = Integer.parseInt(text1)
-			val number2 = Integer.parseInt(text2)
-			return number1.compareInt(number2)
+			// Try reading first element as number and second as text 
+			return Integer.parseInt(first) -> second
 		} catch (NumberFormatException e) {
-			return text1.compareString(text2)
+			// Otherwise it is all text
+			return null -> first + second
 		}
 	}
 
+	def int compareCell(Iterable<String> iterable1,
+		Iterable<String> iterable2) {
+		// For compare, the separator should be empty
+		val text1 = iterable1.iterableToString("")
+		val text2 = iterable2.iterableToString("")
+		val item1 = extractNumericPrefix(text1)
+		val item2 = extractNumericPrefix(text2)
+
+		if (item1.key !== null && item2.key !== null) {
+			val intCompare = item1.key.compareInt(item2.key)
+			if (intCompare !== 0)
+				return intCompare
+
+			return item1.value.compareString(item2.value)
+		}
+
+		return item1.value.compareString(item2.value)
+	}
+
 	def int compareString(String text1, String text2)
-	
+
 	def compareInt(int number1, int number2) {
 		if (direction == SortDirectionEnum.ASC) {
 			return number1.compareTo(number2)
 		}
 		return number2.compareTo(number1)
 	}
-	
+
 }


### PR DESCRIPTION
Java comparators must be transitive. 

Previously our cell comparator worked the following way:

1. Attempt to convert both values to ints and compare those
2. Compare the text representation of both values

However that leads to the comparator not being transitive as required by sorting algorithms. For example consider 

```
57 < 5100 (numeric)
56AA > 5100 (text)
57 > 56AA (text)
```
This leads to:
```
56AA < 57 < 5100 < 56AA
```

Instead we attempt to compare a numeric prefix. If the numeric prefixes are equal, attempt to match the remaining text (if any). 

