### PR TITLE
Fix Ssld target track segment length always being zero

### DIFF
--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/BereichObjektExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/BereichObjektExtensions.xtend
@@ -585,7 +585,7 @@ class BereichObjektExtensions extends BasisObjektExtensions {
 	def static BigDecimal getOverlappingLength(
 		Bereich_Objekt_Teilbereich_AttributeGroup tba,
 		Bereich_Objekt_Teilbereich_AttributeGroup tbb) {
-		if (tba.IDTOPKante !== tbb.IDTOPKante)
+		if (tba.IDTOPKante.value !== tbb.IDTOPKante.value)
 			return BigDecimal.ZERO
 
 		val taA = tba.begrenzungA?.wert


### PR DESCRIPTION
The two pointer objects may be different instances since the removal of toolboxmodel.