### PR TITLE
Trigger CI build on PR creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,16 @@
 name: Build SET
 
 on: 
+  repository_dispatch:
+  pull_request:
   push:
+    tags:
+      - 'v**'
+    branches:
+      - 'release/**'
+      - 'main'
     paths-ignore:
       - DEPENDENCIES
-  repository_dispatch:
 
 env:
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - release/*
+    paths-ignore:
+      - DEPENDENCIES
 
 jobs:
   dependencies:


### PR DESCRIPTION
CI builds should run if any of the following is true:

- A PR was opened
- Something is pushed to main or a release branch
- A release tag is created

Also disables retriggering of DEPENDENCIES updates by themselves. 