### PR TITLE
Fix collapsing rows incorrectly applying with filters

### DIFF
--- a/java/bundles/org.eclipse.set.utils.table/src/org/eclipse/set/utils/table/tree/TreeDataProvider.xtend
+++ b/java/bundles/org.eclipse.set.utils.table/src/org/eclipse/set/utils/table/tree/TreeDataProvider.xtend
@@ -285,7 +285,7 @@ class TreeDataProvider extends TableDataProvider implements ITreeData<TableRowDa
 			return
 		}
 		val childsIndex = parentRow.children.map[rowIndex]
-		if (hiddenRowsIndex.containsAll(childsIndex)) {
+		if (childsIndex.exists[hiddenRowsIndex.contains(it)]) {
 			hiddenRowsIndex.removeAll(childsIndex)
 		} else {
 			hiddenRowsIndex.addAll(childsIndex)


### PR DESCRIPTION
If a filter is active, not all child rows may be present to check for.