### PR TITLE
Improve stability for invalid planning data

### DIFF
--- a/java/bundles/org.eclipse.set.application/src/org/eclipse/set/application/geometry/GeoKanteGeometryServiceImpl.java
+++ b/java/bundles/org.eclipse.set.application/src/org/eclipse/set/application/geometry/GeoKanteGeometryServiceImpl.java
@@ -38,6 +38,7 @@ import org.eclipse.set.basis.geometry.GEOKanteMetadata;
 import org.eclipse.set.basis.geometry.GEOKanteSegment;
 import org.eclipse.set.basis.geometry.GeoPosition;
 import org.eclipse.set.basis.geometry.Geometries;
+import org.eclipse.set.basis.geometry.GeometryException;
 import org.eclipse.set.basis.geometry.SegmentPosition;
 import org.eclipse.set.basis.graph.DirectedElement;
 import org.eclipse.set.core.services.Services;
@@ -159,9 +160,14 @@ public class GeoKanteGeometryServiceImpl
 			if (Thread.currentThread().isInterrupted()) {
 				throw new InterruptedException();
 			}
-			final LineString geometry = defineEdgeGeometry(edge);
-			if (geometry != null) {
-				edgeGeometry.put(edge, geometry);
+			try {
+				final LineString geometry = defineEdgeGeometry(edge);
+				if (geometry != null) {
+					edgeGeometry.put(edge, geometry);
+				}
+			} catch (final GeometryException e) {
+				logger.warn("Cannot determine geometry for edge {}.", //$NON-NLS-1$
+						edge.getIdentitaet().getWert());
 			}
 		}
 	}

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/SignalBefestigungExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/SignalBefestigungExtensions.xtend
@@ -36,7 +36,7 @@ class SignalBefestigungExtensions extends BasisObjektExtensions {
 		Signal_Befestigung mount) {
 		val mounts = newArrayList
 		var current = mount
-		while (current !== null) {
+		while (current !== null && !mounts.contains(current)) {		
 			mounts.add(current)
 			current = current.signalBefestigung
 		}


### PR DESCRIPTION
- If a geometry cannot be found for a single edge, we should not abort the entire geometry run
- If a Signal_Befestigung is mounted to itself, we previously ran into an infinite loop