### PR TITLE
Only update estw table, when control area changed

### DIFF
--- a/java/bundles/org.eclipse.set.application/src/org/eclipse/set/application/table/TableMenuServiceImpl.java
+++ b/java/bundles/org.eclipse.set.application/src/org/eclipse/set/application/table/TableMenuServiceImpl.java
@@ -141,8 +141,8 @@ public class TableMenuServiceImpl implements TableMenuService {
 							return;
 						}
 						String tableIdPrefix = ToolboxConstants.ESTW_TABLE_PART_ID_PREFIX;
-						if (jumpEvent
-								.getTableCategory() == ToolboxConstants.ETCS_CATEGORY) {
+						if (jumpEvent.getTableCategory()
+								.equals(ToolboxConstants.ETCS_CATEGORY)) {
 							tableIdPrefix = ToolboxConstants.ETCS_TABLE_PART_ID_PREFIX;
 						}
 						toolboxPartService.showPart(tableIdPrefix + "." //$NON-NLS-1$

--- a/java/bundles/org.eclipse.set.feature.table/src/org/eclipse/set/feature/table/TableService.java
+++ b/java/bundles/org.eclipse.set.feature.table/src/org/eclipse/set/feature/table/TableService.java
@@ -9,6 +9,7 @@
 package org.eclipse.set.feature.table;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -125,13 +126,16 @@ public interface TableService {
 	/**
 	 * @param part
 	 *            the table part
+	 * @param tableCategories
+	 *            the list of table category. when the list is empty, then
+	 *            update all table
 	 * @param updateTableHandler
 	 *            the update table handler
 	 * @param clearInstance
 	 *            the clear table instance handler
 	 */
-	void updateTable(final BasePart part, final Runnable updateTableHandler,
-			Runnable clearInstance);
+	void updateTable(BasePart part, List<String> tableCategories,
+			Runnable updateTableHandler, Runnable clearInstance);
 
 	/**
 	 * Get fixed columns
@@ -140,4 +144,5 @@ public interface TableService {
 	 * @return position of fixed columns
 	 */
 	Set<Integer> getFixedColumns(final String elementID);
+
 }

--- a/java/bundles/org.eclipse.set.feature.table/src/org/eclipse/set/feature/table/internal/TableServiceImpl.java
+++ b/java/bundles/org.eclipse.set.feature.table/src/org/eclipse/set/feature/table/internal/TableServiceImpl.java
@@ -454,13 +454,20 @@ public final class TableServiceImpl implements TableService {
 
 	@Override
 	public void updateTable(final BasePart tablePart,
+			final List<String> tableCategories,
 			final Runnable updateTableHandler, final Runnable clearInstance) {
+		// Find which table categories should be update
+		final List<String> tablePrefixes = List
+				.of(ToolboxConstants.ESTW_TABLE_PART_ID_PREFIX,
+						ToolboxConstants.ETCS_TABLE_PART_ID_PREFIX)
+				.stream()
+				.filter(prefix -> tableCategories.isEmpty()
+						|| tableCategories.stream().anyMatch(prefix::contains))
+				.toList();
 		// Get already open table parts
 		final List<MPart> openTableParts = partService.getOpenParts().stream()
-				.filter(part -> (part.getElementId()
-						.startsWith(ToolboxConstants.ESTW_TABLE_PART_ID_PREFIX)
-						|| part.getElementId().startsWith(
-								ToolboxConstants.ETCS_TABLE_PART_ID_PREFIX))
+				.filter(part -> tablePrefixes.stream().anyMatch(
+						prefix -> part.getElementId().startsWith(prefix))
 						// IMPROVE: currently table overview isn't regard on
 						// control area
 						&& !part.getElementId()

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/FstrZugRangierExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/FstrZugRangierExtensions.xtend
@@ -41,7 +41,6 @@ import org.eclipse.set.ppmodel.extensions.utils.WeichenSchenkel
 
 import static org.eclipse.set.model.planpro.Signale.ENUMSignalArt.*
 
-import static extension org.eclipse.set.ppmodel.extensions.BereichObjektExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.BueAnlageExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.BueEinschaltungZuordnungExtension.*
 import static extension org.eclipse.set.ppmodel.extensions.BueGleisbezogenerGefahrraumExtensions.*
@@ -52,8 +51,8 @@ import static extension org.eclipse.set.ppmodel.extensions.PunktObjektTopKanteEx
 import static extension org.eclipse.set.ppmodel.extensions.SignalExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.SignalRahmenExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.SignalbegriffExtensions.*
-import static extension org.eclipse.set.ppmodel.extensions.WKrGspKomponenteExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.StellBereichExtensions.*
+import static extension org.eclipse.set.ppmodel.extensions.WKrGspKomponenteExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.utils.IterableExtensions.*
 import static extension org.eclipse.set.utils.math.BigIntegerExtensions.*
 
@@ -442,29 +441,28 @@ class FstrZugRangierExtensions extends BasisObjektExtensions {
 
 	private def static boolean isRangierStrBelongToControlArea(
 		Fstr_Zug_Rangier fstrZugRangier, Stell_Bereich controlArea) {
-		if (fstrZugRangier.fstrRangier === null) {
+		if (fstrZugRangier?.fstrRangier === null) {
 			return false
 		}
-		val startSignal = fstrZugRangier.IDFstrFahrweg?.value?.IDStart?.value
+		val startSignal = fstrZugRangier?.IDFstrFahrweg?.value?.IDStart?.value
 		return controlArea.isInControlArea(startSignal)
 	}
 
 	private def static boolean isZugStrBelongToControlArea(
 		Fstr_Zug_Rangier fstrZugRangier, Stell_Bereich controlArea) {
-		if (fstrZugRangier.fstrZug === null &&
-			fstrZugRangier.fstrMittel === null) {
+		if (fstrZugRangier?.fstrZug === null &&
+			fstrZugRangier?.fstrMittel === null) {
 			return false
 		}
-		val startSignal = fstrZugRangier.IDFstrFahrweg?.value?.IDStart?.value
+		val startSignal = fstrZugRangier?.IDFstrFahrweg?.value?.IDStart?.value
 		val zielSignal = fstrZugRangier?.IDFstrFahrweg?.value?.IDZiel?.value
 		if (startSignal === null || zielSignal === null) {
 			return false
 		}
-		
-		return 				zielSignal.container.fstrZugRangier.exists [
-					fstrZug.fstrZugArt.wert ===
-						ENUMFstrZugArt.ENUM_FSTR_ZUG_ART_B &&
-						IDFstrFahrweg?.value?.IDStart?.value === zielSignal
-				] ? startSignal.isBelongToControlArea(controlArea) : false
+
+		return zielSignal.container.fstrZugRangier.exists [
+			fstrZug?.fstrZugArt?.wert === ENUMFstrZugArt.ENUM_FSTR_ZUG_ART_B &&
+				IDFstrFahrweg?.value?.IDStart?.value === zielSignal
+		] ? startSignal.isBelongToControlArea(controlArea) : false
 	}
 }

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/StellelementExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/StellelementExtensions.xtend
@@ -26,7 +26,7 @@ class StellelementExtensions extends BasisObjektExtensions {
 	 * Stellelement 
 	 */
 	def static Aussenelementansteuerung getEnergie(Stellelement stellelement) {
-		return stellelement.IDEnergie?.value
+		return stellelement?.IDEnergie?.value
 	}
 
 	/**
@@ -37,12 +37,12 @@ class StellelementExtensions extends BasisObjektExtensions {
 	 */
 	def static Aussenelementansteuerung getInformation(
 		Stellelement stellelement) {
-		return stellelement.IDInformation?.value
+		return stellelement?.IDInformation?.value
 	}
 
 	def static boolean isBelongToControlArea(Stellelement stellElement,
 		Stell_Bereich area) {
-		return stellElement.IDInformation?.value ===
+		return stellElement?.IDInformation?.value ===
 			area.aussenElementAnsteuerung
 	}
 }


### PR DESCRIPTION
- The ETCS tables aren't regard to Control Area, that mean the ETCS tables will not update when control area changed.
- The ETCS will reloading, when value `Planingbereich` or `gesamt Dateiinhalt` was selected