### PR TITLE
Use BigDecimal instead of Double

### DIFF
--- a/java/bundles/org.eclipse.set.application/src/org/eclipse/set/application/geometry/PointObjectPositionServiceImpl.java
+++ b/java/bundles/org.eclipse.set.application/src/org/eclipse/set/application/geometry/PointObjectPositionServiceImpl.java
@@ -12,6 +12,7 @@ package org.eclipse.set.application.geometry;
 
 import static org.eclipse.set.ppmodel.extensions.EObjectExtensions.getNullableObject;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.eclipse.set.basis.geometry.GEOKanteCoordinate;
@@ -68,7 +69,7 @@ public class PointObjectPositionServiceImpl
 				|| punktObjekt instanceof Signal_Befestigung) {
 			return getSignalObjectCoordinate(punktObjekt);
 		}
-		return geometryService.getCoordinateAt(punktObjekt, 0.0);
+		return geometryService.getCoordinateAt(punktObjekt, BigDecimal.ZERO);
 	}
 
 	@Override
@@ -79,7 +80,7 @@ public class PointObjectPositionServiceImpl
 			return null;
 		}
 
-		final double lateralDistance = getLateralDistance(singlePoint,
+		final BigDecimal lateralDistance = getLateralDistance(singlePoint,
 				geoKante);
 		return getCoordinate(singlePoint, lateralDistance);
 	}
@@ -87,7 +88,7 @@ public class PointObjectPositionServiceImpl
 	@Override
 	public GEOKanteCoordinate getCoordinate(
 			final Punkt_Objekt_TOP_Kante_AttributeGroup singlePoint,
-			final double lateralDistance) {
+			final BigDecimal lateralDistance) {
 
 		final GEOKanteMetadata geoKante = getGeoKanteMetadata(singlePoint);
 		if (geoKante == null) {
@@ -97,8 +98,7 @@ public class PointObjectPositionServiceImpl
 		if (singlePoint.getWirkrichtung() != null) {
 			direction = singlePoint.getWirkrichtung().getWert();
 		}
-		final double distance = singlePoint.getAbstand().getWert()
-				.doubleValue();
+		final BigDecimal distance = singlePoint.getAbstand().getWert();
 		if (direction == ENUMWirkrichtung.ENUM_WIRKRICHTUNG_BEIDE) {
 			// For Punkt_Objekte with a bilateral direction fall back to
 			// ENUM_WIRKRICHTUNG_IN
@@ -117,8 +117,7 @@ public class PointObjectPositionServiceImpl
 			return null;
 		}
 
-		final double distance = singlePoint.getAbstand().getWert()
-				.doubleValue();
+		final BigDecimal distance = singlePoint.getAbstand().getWert();
 
 		final TOP_Kante topKante = singlePoint.getIDTOPKante().getValue();
 		final TOP_Knoten topKnotenA = topKante.getIDTOPKnotenA().getValue();
@@ -126,15 +125,15 @@ public class PointObjectPositionServiceImpl
 		return geometryService.getGeoKanteAt(topKante, topKnotenA, distance);
 	}
 
-	private static double getLateralDistance(
+	private static BigDecimal getLateralDistance(
 			final Punkt_Objekt_TOP_Kante_AttributeGroup singlePoint,
 			final GEOKanteMetadata geoKante) {
 		if (singlePoint.getSeitlicherAbstand() != null
 				&& singlePoint.getSeitlicherAbstand().getWert() != null) {
-			return singlePoint.getSeitlicherAbstand().getWert().doubleValue();
+			return singlePoint.getSeitlicherAbstand().getWert();
 		}
-		final double distance = singlePoint.getSeitlicherAbstand().getWert()
-				.doubleValue();
+		final BigDecimal distance = singlePoint.getSeitlicherAbstand()
+				.getWert();
 		// Determine the track type
 		final GEOKanteSegment segment = geoKante.getContainingSegment(distance);
 		final List<ENUMGleisart> trackType = segment.getBereichObjekte()
@@ -145,7 +144,7 @@ public class PointObjectPositionServiceImpl
 		// Determine the object distance according to the local track type
 		if (trackType.isEmpty()) {
 			// No local track type. Default to 0 and record an error
-			return 0;
+			return BigDecimal.ZERO;
 		}
 		final double lateralDistance = trackType
 				.getFirst() == ENUMGleisart.ENUM_GLEISART_STRECKENGLEIS
@@ -154,8 +153,8 @@ public class PointObjectPositionServiceImpl
 		final ENUMLinksRechts side = getNullableObject(singlePoint,
 				point -> point.getSeitlicheLage().getWert()).orElse(null);
 		if (side != null && side == ENUMLinksRechts.ENUM_LINKS_RECHTS_LINKS) {
-			return -lateralDistance;
+			return BigDecimal.valueOf(-lateralDistance);
 		}
-		return lateralDistance;
+		return BigDecimal.valueOf(lateralDistance);
 	}
 }

--- a/java/bundles/org.eclipse.set.application/src/org/eclipse/set/application/graph/BankServiceImpl.java
+++ b/java/bundles/org.eclipse.set.application/src/org/eclipse/set/application/graph/BankServiceImpl.java
@@ -200,9 +200,10 @@ public class BankServiceImpl implements BankService, EventHandler {
 				+ ToolboxConfiguration.getBankLineTopOffsetLimit() + 1);
 
 		final Predicate<TopPath> predicate = t -> {
-			final double diff = Math.abs(
-					t.length().doubleValue() - bankingLineLength.doubleValue());
-			return diff < ToolboxConfiguration.getBankLineTopOffsetLimit();
+			final BigDecimal diff = t.length().subtract(bankingLineLength)
+					.abs();
+			return diff.doubleValue() < ToolboxConfiguration
+					.getBankLineTopOffsetLimit();
 		};
 		final TopPath path = topGraph.findPathBetween(new TopPoint(begin),
 				new TopPoint(end), limit, predicate);

--- a/java/bundles/org.eclipse.set.basis.test/src/org/eclipse/set/basis/graph/testmodel/TestDigraph.java
+++ b/java/bundles/org.eclipse.set.basis.test/src/org/eclipse/set/basis/graph/testmodel/TestDigraph.java
@@ -9,6 +9,7 @@
 
 package org.eclipse.set.basis.graph.testmodel;
 
+import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.Set;
 
@@ -35,8 +36,8 @@ public class TestDigraph extends AbstractDigraph<String, Character, Integer> {
 	}
 
 	@Override
-	public Comparator<Double> getDistanceComparator() {
-		return Double::compare;
+	public Comparator<BigDecimal> getDistanceComparator() {
+		return BigDecimal::compareTo;
 	}
 
 	@Override

--- a/java/bundles/org.eclipse.set.basis.test/src/org/eclipse/set/basis/graph/testmodel/TestEdge.java
+++ b/java/bundles/org.eclipse.set.basis.test/src/org/eclipse/set/basis/graph/testmodel/TestEdge.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.set.basis.graph.testmodel;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -76,18 +77,18 @@ public class TestEdge implements DirectedEdge<String, Character, Integer> {
 	}
 
 	@Override
-	public double distance(final Integer p1, final Integer p2) {
+	public BigDecimal distance(final Integer p1, final Integer p2) {
 		final int i1 = points.indexOf(p1);
 		checkIndex(i1, p1);
 		final int i2 = points.indexOf(p2);
 		checkIndex(i2, p2);
 
 		// all points have a distance of 1 to each other
-		return Math.abs(i2 - i1);
+		return BigDecimal.valueOf(Math.abs(i2 - i1));
 	}
 
 	@Override
-	public double distanceFromTail(final Integer point) {
+	public BigDecimal distanceFromTail(final Integer point) {
 		checkPoint(point);
 
 		// we have a first point, because "point" is a point on this edge
@@ -97,7 +98,7 @@ public class TestEdge implements DirectedEdge<String, Character, Integer> {
 	}
 
 	@Override
-	public double distanceToHead(final Integer point) {
+	public BigDecimal distanceToHead(final Integer point) {
 		checkPoint(point);
 
 		// we have a last point, because "point" is a point on this edge
@@ -131,8 +132,8 @@ public class TestEdge implements DirectedEdge<String, Character, Integer> {
 	}
 
 	@Override
-	public double getLength() {
-		return points.size();
+	public BigDecimal getLength() {
+		return BigDecimal.valueOf(points.size());
 	}
 
 	@Override

--- a/java/bundles/org.eclipse.set.basis.test/src/org/eclipse/set/basis/graph/testmodel/TestPath.java
+++ b/java/bundles/org.eclipse.set.basis.test/src/org/eclipse/set/basis/graph/testmodel/TestPath.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.set.basis.graph.testmodel;
 
+import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.List;
 
@@ -50,8 +51,8 @@ public class TestPath
 	}
 
 	@Override
-	public Comparator<Double> getDistanceComparator() {
-		return Double::compareTo;
+	public Comparator<BigDecimal> getDistanceComparator() {
+		return BigDecimal::compareTo;
 	}
 
 	@Override

--- a/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/constants/ToolboxConstants.java
+++ b/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/constants/ToolboxConstants.java
@@ -282,6 +282,11 @@ public final class ToolboxConstants {
 	public static final String ETCS_CATEGORY = "etcs"; //$NON-NLS-1$
 
 	/**
+	 * Rounding result of BigDecimal.divide to place after comma
+	 */
+	public static final int ROUNDING_TO_PLACE = 5;
+
+	/**
 	 * The id of the web developer help part
 	 */
 	public static String WEB_DEVELOPER_HELP_PART_ID = "org.eclipse.set.application.ppt.nosessionpart.WebDeveloperHelpPart";

--- a/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/geometry/GEOKanteSegment.java
+++ b/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/geometry/GEOKanteSegment.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.set.basis.geometry;
 
+import java.math.BigDecimal;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -22,8 +23,8 @@ import org.eclipse.set.model.planpro.Basisobjekte.Bereich_Objekt;
  */
 public class GEOKanteSegment {
 	protected final Set<Bereich_Objekt> bereichObjekte;
-	protected double length;
-	protected double start;
+	protected BigDecimal length;
+	protected BigDecimal start;
 
 	/**
 	 * @param start
@@ -31,7 +32,7 @@ public class GEOKanteSegment {
 	 * @param length
 	 *            the length of the segment
 	 */
-	public GEOKanteSegment(final double start, final double length) {
+	public GEOKanteSegment(final BigDecimal start, final BigDecimal length) {
 		this.start = start;
 		this.length = length;
 		this.bereichObjekte = new HashSet<>();
@@ -59,7 +60,7 @@ public class GEOKanteSegment {
 	/**
 	 * @return the length of the segment
 	 */
-	public double getLength() {
+	public BigDecimal getLength() {
 		return length;
 	}
 
@@ -68,7 +69,7 @@ public class GEOKanteSegment {
 	 *         start of the original TOP_Kante that was used to determine this
 	 *         segment object
 	 */
-	public double getStart() {
+	public BigDecimal getStart() {
 		return start;
 	}
 
@@ -76,15 +77,15 @@ public class GEOKanteSegment {
 	 * @return the end of the segment as defined per {@link #getStart()} +
 	 *         {@link #getLength()}
 	 */
-	public double getEnd() {
-		return start + length;
+	public BigDecimal getEnd() {
+		return start.add(length);
 	}
 
 	/**
 	 * @param length
 	 *            the length to set
 	 */
-	public void setLength(final double length) {
+	public void setLength(final BigDecimal length) {
 		this.length = length;
 	}
 
@@ -92,7 +93,7 @@ public class GEOKanteSegment {
 	 * @param start
 	 *            the start distance to set
 	 */
-	public void setStart(final double start) {
+	public void setStart(final BigDecimal start) {
 		this.start = start;
 	}
 }

--- a/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/geometry/Geometries.java
+++ b/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/geometry/Geometries.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.set.basis.geometry;
 
+import java.math.BigDecimal;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -100,12 +101,13 @@ public class Geometries {
 	 */
 	public static SegmentPosition getSegmentPosition(
 			final LineString lineString, final Coordinate start,
-			final double distance) throws IllegalLineStringDistance {
+			final BigDecimal distance) throws IllegalLineStringDistance {
 		final List<DirectedElementImpl<LineSegment>> segments = getSegments(
 				DirectedElementImpl.forwards(lineString), start);
 		final SegmentPosition position = getSegmentPosition(segments, distance);
 		if (position == null) {
-			throw new IllegalLineStringDistance(lineString, distance);
+			throw new IllegalLineStringDistance(lineString,
+					distance.doubleValue());
 		}
 		return position;
 	}
@@ -205,16 +207,17 @@ public class Geometries {
 
 	private static SegmentPosition getSegmentPosition(
 			final List<DirectedElementImpl<LineSegment>> segments,
-			final double distance) {
+			final BigDecimal distance) {
 		if (segments.isEmpty()) {
 			return null;
 		}
 		final DirectedElementImpl<LineSegment> head = Lists.head(segments);
 		final double length = head.getElement().getLength();
-		if (distance <= length + ACCURACY) {
+		if (distance.doubleValue() <= length + ACCURACY) {
 			return new SegmentPosition(head, distance);
 		}
-		return getSegmentPosition(Lists.tail(segments), distance - length);
+		return getSegmentPosition(Lists.tail(segments),
+				distance.subtract(BigDecimal.valueOf(length)));
 	}
 
 	private static List<DirectedElementImpl<LineSegment>> getSegments(

--- a/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/geometry/SegmentPosition.java
+++ b/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/geometry/SegmentPosition.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.set.basis.geometry;
 
+import java.math.BigDecimal;
+
 import org.eclipse.set.basis.graph.DirectedElement;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineSegment;
@@ -30,9 +32,9 @@ public class SegmentPosition {
 	 */
 	public SegmentPosition(
 			final DirectedElement<LineSegment> directedLineSegment,
-			final double distance) {
+			final BigDecimal distance) {
 		this.directedlineSegment = directedLineSegment;
-		this.distance = distance;
+		this.distance = distance.doubleValue();
 	}
 
 	/**

--- a/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/graph/AbstractDirectedEdgePath.java
+++ b/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/graph/AbstractDirectedEdgePath.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.set.basis.graph;
 
+import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -91,7 +92,7 @@ public abstract class AbstractDirectedEdgePath<E, N, P>
 	}
 
 	@Override
-	public double distance(final P p1, final P p2) {
+	public BigDecimal distance(final P p1, final P p2) {
 		if (p1 == null) {
 			return distanceFromStart(p2);
 		}
@@ -116,8 +117,7 @@ public abstract class AbstractDirectedEdgePath<E, N, P>
 
 	@Override
 	public boolean equals(final Object obj) {
-		if (obj instanceof DirectedEdgePath<?, ?, ?>) {
-			final DirectedEdgePath<?, ?, ?> path = (DirectedEdgePath<?, ?, ?>) obj;
+		if (obj instanceof final DirectedEdgePath<?, ?, ?> path) {
 			return equals(path.getStart(), getStart())
 					&& equals(path.getEnd(), getEnd())
 					&& equals(path.getEdgeList(), getEdgeList());
@@ -200,9 +200,7 @@ public abstract class AbstractDirectedEdgePath<E, N, P>
 			// checking to fail fast but this is out of scope here.
 			final List<P> pointList = edgeToPointsCache.get(edge.getCacheKey(),
 					() -> getPointList(edge));
-			final Iterator<P> pointIter = pointList.iterator();
-			while (pointIter.hasNext()) {
-				final P point = pointIter.next();
+			for (final P point : pointList) {
 				directedEdgePoints.add(new DirectedEdgePoint<>(edge, point));
 			}
 		}
@@ -266,7 +264,7 @@ public abstract class AbstractDirectedEdgePath<E, N, P>
 	}
 
 	@Override
-	public double getLength() {
+	public BigDecimal getLength() {
 		return distance(getStart(), getEnd());
 	}
 
@@ -316,11 +314,11 @@ public abstract class AbstractDirectedEdgePath<E, N, P>
 				return createSubPath(startIdx, endIdx, subStart, subEnd);
 			}
 			if (startIdx == endIdx) {
-				final Double subStartDistance = Double
-						.valueOf(startEdge.distanceFromTail(subStart));
-				final Double subEndDistance = Double
-						.valueOf(endEdge.distanceFromTail(subEnd));
-				final Comparator<Double> distanceComparator = getDistanceComparator();
+				final BigDecimal subStartDistance = startEdge
+						.distanceFromTail(subStart);
+				final BigDecimal subEndDistance = endEdge
+						.distanceFromTail(subEnd);
+				final Comparator<BigDecimal> distanceComparator = getDistanceComparator();
 				if (distanceComparator.compare(subStartDistance,
 						subEndDistance) <= 0) {
 					return createSubPath(startIdx, endIdx, subStart, subEnd);
@@ -356,33 +354,33 @@ public abstract class AbstractDirectedEdgePath<E, N, P>
 		return result;
 	}
 
-	private double distance(final P pStart, final int idxStart, final P pEnd,
-			final int idxEnd) {
+	private BigDecimal distance(final P pStart, final int idxStart,
+			final P pEnd, final int idxEnd) {
 		if (idxStart > idxEnd) {
-			return 0;
+			return BigDecimal.ZERO;
 		}
 
 		if (idxStart != idxEnd) {
-			final double startDistance;
+			BigDecimal startDistance;
 			if (pStart != null) {
 				startDistance = get(idxStart).distanceToHead(pStart);
 			} else {
 				startDistance = get(idxStart).getLength();
 			}
 
-			final double endDistance;
+			BigDecimal endDistance;
 			if (pEnd != null) {
 				endDistance = get(idxEnd).distanceFromTail(pEnd);
 			} else {
 				endDistance = get(idxEnd).getLength();
 			}
 
-			double inBetweenDistance = 0;
+			BigDecimal inBetweenDistance = BigDecimal.ZERO;
 			for (int i = idxStart + 1; i < idxEnd; i++) {
-				inBetweenDistance = inBetweenDistance + get(i).getLength();
+				inBetweenDistance = inBetweenDistance.add(get(i).getLength());
 			}
 
-			return startDistance + inBetweenDistance + endDistance;
+			return startDistance.add(inBetweenDistance).add(endDistance);
 		}
 
 		// idxStart == idxEnd
@@ -395,7 +393,7 @@ public abstract class AbstractDirectedEdgePath<E, N, P>
 		return get(idxStart).distanceToHead(pStart);
 	}
 
-	private double distanceFromStart(final P p) {
+	private BigDecimal distanceFromStart(final P p) {
 		if (getStart() != null) {
 			return distance(getStart(), p);
 		}
@@ -405,7 +403,7 @@ public abstract class AbstractDirectedEdgePath<E, N, P>
 		return distance(null, 0, null, edges.size() - 1);
 	}
 
-	private double distanceToEnd(final P p) {
+	private BigDecimal distanceToEnd(final P p) {
 		if (getEnd() != null) {
 			return distance(getEnd(), p);
 		}

--- a/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/graph/Digraphs.java
+++ b/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/graph/Digraphs.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.set.basis.graph;
 
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -123,7 +124,7 @@ public class Digraphs {
 	 */
 	public static <E, N, P> Set<DirectedEdgePath<E, N, P>> getPaths(
 			final DirectedEdge<E, N, P> start, final Routing<E, N, P> routing) {
-		return getPaths(start, routing, -1);
+		return getPaths(start, routing, BigDecimal.ONE.negate());
 	}
 
 	/**
@@ -146,7 +147,7 @@ public class Digraphs {
 	 */
 	public static <E, N, P> Set<DirectedEdgePath<E, N, P>> getPaths(
 			final DirectedEdge<E, N, P> start, final Routing<E, N, P> routing,
-			final double minDistance) {
+			final BigDecimal minDistance) {
 		createCache();
 		return edgeToSubPathCache.get(
 				getPathCacheKey(start, routing, minDistance),
@@ -155,15 +156,15 @@ public class Digraphs {
 
 	private static <E, N, P> String getPathCacheKey(
 			final DirectedEdge<E, N, P> start, final Routing<E, N, P> routing,
-			final double minDistance) {
+			final BigDecimal minDistance) {
 		final List<String> components = List.of(start.getCacheKey(),
-				Double.toString(minDistance), routing.getCacheKey());
+				minDistance.toString(), routing.getCacheKey());
 		return String.join("/", components); //$NON-NLS-1$
 	}
 
 	private static <E, N, P> Set<DirectedEdgePath<E, N, P>> calculateSubPaths(
 			final DirectedEdge<E, N, P> start, final Routing<E, N, P> routing,
-			final double minDistance) {
+			final BigDecimal minDistance) {
 		final Set<DirectedEdgePath<E, N, P>> subpaths = getSubPaths(start,
 				minDistance, routing, routing.getEmptyPath());
 		for (final DirectedEdgePath<E, N, P> path : subpaths) {
@@ -347,7 +348,7 @@ public class Digraphs {
 			}
 
 			@Override
-			public Comparator<Double> getDistanceComparator() {
+			public Comparator<BigDecimal> getDistanceComparator() {
 				if (aPath != null) {
 					return aPath.getDistanceComparator();
 				}
@@ -395,7 +396,7 @@ public class Digraphs {
 	}
 
 	private static <E, N, P> Set<DirectedEdgePath<E, N, P>> getSubPaths(
-			final DirectedEdge<E, N, P> start, final double minDistance,
+			final DirectedEdge<E, N, P> start, final BigDecimal minDistance,
 			final Routing<E, N, P> routing,
 			final DirectedEdgePath<E, N, P> path) {
 		logger.debug("start={} path={}", start, path); //$NON-NLS-1$
@@ -413,11 +414,11 @@ public class Digraphs {
 
 				// test if the min distance is exceeded and ignore the distance,
 				// if min distance < 0
-				final Comparator<Double> comparator = routing
+				final Comparator<BigDecimal> comparator = routing
 						.getDistanceComparator();
-				if (comparator.compare(
-						Double.valueOf(successorPath.getLength()),
-						Double.valueOf(minDistance)) < 0 || minDistance < 0) {
+				if (comparator.compare(successorPath.getLength(),
+						minDistance) < 0
+						|| minDistance.compareTo(BigDecimal.ZERO) < 0) {
 					final Set<DirectedEdgePath<E, N, P>> subPaths = getSubPaths(
 							successor, minDistance, routing, successorPath);
 					if (subPaths.isEmpty()) {

--- a/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/graph/DirectedEdge.java
+++ b/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/graph/DirectedEdge.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.set.basis.graph;
 
+import java.math.BigDecimal;
 import java.util.Iterator;
 
 /**
@@ -40,7 +41,7 @@ public interface DirectedEdge<E, N, P> extends DirectedElement<E> {
 	 * 
 	 * @return the distance of the point objects
 	 */
-	double distance(P p1, P p2);
+	BigDecimal distance(P p1, P p2);
 
 	/**
 	 * @param p
@@ -49,7 +50,7 @@ public interface DirectedEdge<E, N, P> extends DirectedElement<E> {
 	 * @return the distance from the tail (start) of this edge to the given
 	 *         point object
 	 */
-	double distanceFromTail(P p);
+	BigDecimal distanceFromTail(P p);
 
 	/**
 	 * @param p
@@ -58,7 +59,7 @@ public interface DirectedEdge<E, N, P> extends DirectedElement<E> {
 	 * @return the distance from the given point object to the head (end) of
 	 *         this edge
 	 */
-	double distanceToHead(P p);
+	BigDecimal distanceToHead(P p);
 
 	/**
 	 * @return the head (end) node of this directed edge
@@ -73,7 +74,7 @@ public interface DirectedEdge<E, N, P> extends DirectedElement<E> {
 	/**
 	 * @return the length of this edge
 	 */
-	double getLength();
+	BigDecimal getLength();
 
 	/**
 	 * @return the tail (start) node of this directed edge

--- a/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/graph/DirectedEdgePath.java
+++ b/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/graph/DirectedEdgePath.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.set.basis.graph;
 
+import java.math.BigDecimal;
 import java.util.Iterator;
 import java.util.List;
 
@@ -53,7 +54,7 @@ public interface DirectedEdgePath<E, N, P> extends Digraph<E, N, P> {
 	 * 
 	 * @return the distance between the two points
 	 */
-	double distance(P p1, P p2);
+	BigDecimal distance(P p1, P p2);
 
 	/**
 	 * @param i
@@ -128,7 +129,7 @@ public interface DirectedEdgePath<E, N, P> extends Digraph<E, N, P> {
 	/**
 	 * @return the total length of this path
 	 */
-	double getLength();
+	BigDecimal getLength();
 
 	/**
 	 * Returns an iterator for the point objects of this path. For points

--- a/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/graph/Routing.java
+++ b/java/bundles/org.eclipse.set.basis/src/org/eclipse/set/basis/graph/Routing.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.set.basis.graph;
 
+import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.Set;
 
@@ -46,7 +47,7 @@ public interface Routing<E, N, P> {
 	/**
 	 * @return a comparator to compare distances
 	 */
-	Comparator<Double> getDistanceComparator();
+	Comparator<BigDecimal> getDistanceComparator();
 
 	/**
 	 * @param tail

--- a/java/bundles/org.eclipse.set.core.services/src/org/eclipse/set/core/services/geometry/GeoKanteGeometryService.java
+++ b/java/bundles/org.eclipse.set.core.services/src/org/eclipse/set/core/services/geometry/GeoKanteGeometryService.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.set.core.services.geometry;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.eclipse.set.basis.geometry.GEOKanteCoordinate;
@@ -49,7 +50,7 @@ public interface GeoKanteGeometryService {
 	 * @return the coordinate at punkt objekt with the given distance as offset
 	 */
 	GEOKanteCoordinate getCoordinateAt(Punkt_Objekt punktObjekt,
-			double distance);
+			BigDecimal distance);
 
 	/**
 	 * @param topKante
@@ -65,7 +66,7 @@ public interface GeoKanteGeometryService {
 	 * @return the coordinate
 	 */
 	GEOKanteCoordinate getCoordinate(TOP_Kante topKante, TOP_Knoten start,
-			double distance, double lateralDistance,
+			BigDecimal distance, BigDecimal lateralDistance,
 			ENUMWirkrichtung wirkrichtung);
 
 	/**
@@ -84,8 +85,9 @@ public interface GeoKanteGeometryService {
 	 *         point with the given distance and lateralDistance
 	 * @if the geometry cannot be determined
 	 */
-	GEOKanteCoordinate getCoordinate(GEOKanteMetadata geoKante, double distance,
-			double lateralDistance, ENUMWirkrichtung wirkrichtung);
+	GEOKanteCoordinate getCoordinate(GEOKanteMetadata geoKante,
+			BigDecimal distance, BigDecimal lateralDistance,
+			ENUMWirkrichtung wirkrichtung);
 
 	/**
 	 * @param topKante
@@ -97,7 +99,7 @@ public interface GeoKanteGeometryService {
 	 * @return the GEO_Kante with metadata at the specified distance
 	 */
 	GEOKanteMetadata getGeoKanteAt(TOP_Kante topKante, TOP_Knoten topKnoten,
-			double distance);
+			BigDecimal distance);
 
 	/**
 	 * @param topKante

--- a/java/bundles/org.eclipse.set.core.services/src/org/eclipse/set/core/services/geometry/PointObjectPositionService.java
+++ b/java/bundles/org.eclipse.set.core.services/src/org/eclipse/set/core/services/geometry/PointObjectPositionService.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.set.core.services.geometry;
 
+import java.math.BigDecimal;
+
 import org.eclipse.set.basis.geometry.GEOKanteCoordinate;
 import org.eclipse.set.model.planpro.Basisobjekte.Punkt_Objekt;
 import org.eclipse.set.model.planpro.Basisobjekte.Punkt_Objekt_TOP_Kante_AttributeGroup;
@@ -42,5 +44,5 @@ public interface PointObjectPositionService {
 	 * @return the coordinate at punkt objekt
 	 */
 	GEOKanteCoordinate getCoordinate(Punkt_Objekt_TOP_Kante_AttributeGroup potk,
-			double lateralDistance);
+			BigDecimal lateralDistance);
 }

--- a/java/bundles/org.eclipse.set.feature.plazmodel/src/org/eclipse/set/feature/plazmodel/check/GeoCoordinateValid.java
+++ b/java/bundles/org.eclipse.set.feature.plazmodel/src/org/eclipse/set/feature/plazmodel/check/GeoCoordinateValid.java
@@ -12,6 +12,7 @@ package org.eclipse.set.feature.plazmodel.check;
 
 import static org.eclipse.set.ppmodel.extensions.EObjectExtensions.getNullableObject;
 
+import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -144,13 +145,15 @@ public class GeoCoordinateValid extends AbstractPlazContainerCheck
 		if (po instanceof PZB_Element || po instanceof FMA_Komponente) {
 			final ENUMLinksRechts side = getNullableObject(potk,
 					point -> point.getSeitlicheLage().getWert()).orElse(null);
+			final BigDecimal lateralDistance = BigDecimal
+					.valueOf(FMA_PZB_LATERAL_DISTANCE);
 			if (side != null
 					&& side == ENUMLinksRechts.ENUM_LINKS_RECHTS_LINKS) {
 				return pointObjectPositionService.getCoordinate(potk,
-						-FMA_PZB_LATERAL_DISTANCE);
+						lateralDistance.negate());
 			}
 			return pointObjectPositionService.getCoordinate(potk,
-					FMA_PZB_LATERAL_DISTANCE);
+					lateralDistance);
 
 		}
 		return pointObjectPositionService.getCoordinate(potk);

--- a/java/bundles/org.eclipse.set.feature.siteplan/src/org/eclipse/set/feature/siteplan/transform/PZBTransformator.xtend
+++ b/java/bundles/org.eclipse.set.feature.siteplan/src/org/eclipse/set/feature/siteplan/transform/PZBTransformator.xtend
@@ -8,6 +8,8 @@
  */
 package org.eclipse.set.feature.siteplan.transform
 
+import java.math.BigDecimal
+import org.eclipse.set.core.services.geometry.GeoKanteGeometryService
 import org.eclipse.set.core.services.geometry.PointObjectPositionService
 import org.eclipse.set.feature.siteplan.positionservice.PositionService
 import org.eclipse.set.model.planpro.BasisTypen.ENUMLinksRechts
@@ -27,7 +29,6 @@ import org.osgi.service.component.annotations.Reference
 import static extension org.eclipse.set.feature.siteplan.transform.TransformUtils.*
 import static extension org.eclipse.set.ppmodel.extensions.PZBElementExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.PunktObjektExtensions.*
-import org.eclipse.set.core.services.geometry.GeoKanteGeometryService
 
 /**
  * Transforms PlanPro PZB_Element to Siteplan PZB
@@ -42,8 +43,8 @@ class PZBTransformator extends BaseTransformator<PZB_Element> {
 	@Reference
 	PositionService positionService
 	
-	static val GSA_DISTANCE_AE = 7.0
-	static val GSA_DISTANCE_EA = 3.0
+	static val GSA_DISTANCE_AE = BigDecimal.valueOf(7)
+	static val GSA_DISTANCE_EA = BigDecimal.valueOf(3)
 	
 	@Reference
 	GeoKanteGeometryService geometryService
@@ -105,7 +106,7 @@ class PZBTransformator extends BaseTransformator<PZB_Element> {
 		boolean directionFollowsTopEdge) {
 		val isAE = pzb.PZBElementGUE?.GUEAnordnung?.wert ===
 			ENUMGUEAnordnung.ENUMGUE_ANORDNUNG_2AE
-		val distance = pzb.PZBElementGUE?.GUEMessstrecke?.wert.doubleValue
+		val distance = pzb.PZBElementGUE?.GUEMessstrecke?.wert
 		val gsa = pzb.transformPZB
 		gsa.type = PZBType.GUE_GSA
 		var gsaDistance = isAE ? GSA_DISTANCE_AE + distance : -GSA_DISTANCE_EA
@@ -119,7 +120,7 @@ class PZBTransformator extends BaseTransformator<PZB_Element> {
 
 	private def PZB transformGSE(PZB_Element pzb,
 		boolean directionFollowsTopEdge) {
-		var distance = pzb.PZBElementGUE?.GUEMessstrecke?.wert.doubleValue
+		var distance = pzb.PZBElementGUE?.GUEMessstrecke?.wert
 		val gse = pzb.transformPZB
 		gse.type = PZBType.GUE_GSE
 		if (!directionFollowsTopEdge)

--- a/java/bundles/org.eclipse.set.feature.siteplan/src/org/eclipse/set/feature/siteplan/transform/RouteTransformator.xtend
+++ b/java/bundles/org.eclipse.set.feature.siteplan/src/org/eclipse/set/feature/siteplan/transform/RouteTransformator.xtend
@@ -8,11 +8,14 @@
  */
 package org.eclipse.set.feature.siteplan.transform
 
+import java.math.BigDecimal
 import java.util.List
+import org.eclipse.set.basis.geometry.GEOKanteCoordinate
 import org.eclipse.set.basis.geometry.GEOKanteMetadata
 import org.eclipse.set.basis.geometry.GeometryException
 import org.eclipse.set.core.services.geometry.GeoKanteGeometryService
 import org.eclipse.set.feature.siteplan.positionservice.PositionService
+import org.eclipse.set.model.planpro.BasisTypen.ENUMWirkrichtung
 import org.eclipse.set.model.planpro.Geodaten.GEO_Kante
 import org.eclipse.set.model.planpro.Geodaten.GEO_Knoten
 import org.eclipse.set.model.planpro.Geodaten.Strecke
@@ -28,8 +31,6 @@ import static extension org.eclipse.set.ppmodel.extensions.GeoKnotenExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.StreckeExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.StreckePunktExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.geometry.GEOKanteGeometryExtensions.*
-import org.eclipse.set.basis.geometry.GEOKanteCoordinate
-import org.eclipse.set.model.planpro.BasisTypen.ENUMWirkrichtung
 
 /**
  * Transforms a Strecke from the PlanPro model to a siteplan route
@@ -128,7 +129,7 @@ class RouteTransformator extends BaseTransformator<Strecke> {
 		val result = newArrayList
 		var GEO_Kante geoKante = null
 		var GEO_Knoten geoKnoten = start.geoKnoten
-		var double geoDistance = startMeter
+		var BigDecimal geoDistance = BigDecimal.valueOf(startMeter)
 
 		// Traverse the GEO_Kanten on this Strecke
 		while (true) {
@@ -144,7 +145,7 @@ class RouteTransformator extends BaseTransformator<Strecke> {
 				geoKnoten, geometryService.getGeometry(geoKante))
 
 			// For every 100m on this GEO_Kante, determine the point
-			while (offset <= metadata.end) {
+			while (offset <= metadata.end.doubleValue) {
 				// If we've reached the end of the Strecke, return
 				if (offset >= endMeter)
 					return result
@@ -152,7 +153,7 @@ class RouteTransformator extends BaseTransformator<Strecke> {
 				// Add the point to the result
 				try {
 					result.add(
-						geometryService.getCoordinate(metadata, offset, 0.0,
+						geometryService.getCoordinate(metadata, BigDecimal.valueOf(offset), BigDecimal.ZERO,
 							ENUMWirkrichtung.ENUM_WIRKRICHTUNG_IN) -> offset)
 					offset += STRECKE_KM_SPACING
 				} catch (GeometryException exc) {

--- a/java/bundles/org.eclipse.set.feature.siteplan/src/org/eclipse/set/feature/siteplan/transform/SiteplanTransformatorImpl.xtend
+++ b/java/bundles/org.eclipse.set.feature.siteplan/src/org/eclipse/set/feature/siteplan/transform/SiteplanTransformatorImpl.xtend
@@ -32,6 +32,7 @@ import static extension org.eclipse.set.ppmodel.extensions.PlanProSchnittstelleE
 import static extension org.eclipse.set.ppmodel.extensions.PlanungProjektExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.StreckeExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.StreckePunktExtensions.*
+import java.math.BigDecimal
 
 /**
  * Transforms the PlanPro data model into the siteplan data model 
@@ -105,17 +106,17 @@ class SiteplanTransformatorImpl extends AbstractSiteplanTransformator {
 			return null
 		}
 
-		var double trackKm
+		var BigDecimal routeMeter
 		try {
-			trackKm = Double.parseDouble(
-				mainRouteInfo.streckeKm.wert.replace(",", "")).doubleValue
+			routeMeter = new BigDecimal(
+				mainRouteInfo.streckeKm.wert.replace(",", ""))
 		} catch (ParseException | NumberFormatException exc) {
 			return null
 		}
 		val mainRoute = mainRoutes.head
 		// Determine the coordinate at the point
 		try {
-			val mainCoordinate = mainRoute.getKilometerCoordinate(trackKm)
+			val mainCoordinate = mainRoute.getKilometerCoordinate(routeMeter)
 			val startEnd = mainRoute.startEnd
 			if (startEnd === null)
 				return null

--- a/java/bundles/org.eclipse.set.feature.siteplan/src/org/eclipse/set/feature/siteplan/transform/StationTransformator.xtend
+++ b/java/bundles/org.eclipse.set.feature.siteplan/src/org/eclipse/set/feature/siteplan/transform/StationTransformator.xtend
@@ -8,6 +8,7 @@
  */
 package org.eclipse.set.feature.siteplan.transform
 
+import java.math.BigDecimal
 import org.eclipse.set.core.services.geometry.GeoKanteGeometryService
 import org.eclipse.set.feature.siteplan.positionservice.PositionService
 import org.eclipse.set.model.planpro.Bahnsteig.Bahnsteig_Anlage
@@ -35,7 +36,7 @@ class StationTransformator extends BaseTransformator<Bahnsteig_Anlage> {
 	@Reference
 	PositionService positionService
 
-	static val STATION_TRACK_DISTANCE = 1.7
+	static val STATION_TRACK_DISTANCE = BigDecimal.valueOf(1.7)
 
 	override void transform(Bahnsteig_Anlage station) {
 		val result = SiteplanFactory.eINSTANCE.createStation
@@ -69,10 +70,10 @@ class StationTransformator extends BaseTransformator<Bahnsteig_Anlage> {
 			// Find start and end points	
 			val topKante = tb?.IDTOPKante?.value
 			val start = geometryService.getCoordinate(topKante,
-				topKante?.IDTOPKnotenA?.value, tb.begrenzungA.wert.doubleValue,
+				topKante?.IDTOPKnotenA?.value, tb.begrenzungA.wert,
 				lateralDistance, tb.richtungsbezug.wert)
 			val end = geometryService.getCoordinate(topKante,
-				topKante?.IDTOPKnotenA?.value, tb.begrenzungB.wert.doubleValue,
+				topKante?.IDTOPKnotenA?.value, tb.begrenzungB.wert,
 				lateralDistance, tb.richtungsbezug.wert)
 			result.points.add(positionService.transformPosition(start))
 			result.points.add(positionService.transformPosition(end))

--- a/java/bundles/org.eclipse.set.feature.table.pt1/src/org/eclipse/set/feature/table/pt1/sskp/SskpBahnsteigUtils.java
+++ b/java/bundles/org.eclipse.set.feature.table.pt1/src/org/eclipse/set/feature/table/pt1/sskp/SskpBahnsteigUtils.java
@@ -15,6 +15,7 @@ import static org.eclipse.set.ppmodel.extensions.PunktObjektExtensions.getSingle
 import static org.eclipse.set.ppmodel.extensions.PunktObjektTopKanteExtensions.isBelongToBereichObjekt;
 import static org.eclipse.set.ppmodel.extensions.PunktObjektTopKanteExtensions.isWirkrichtungTopDirection;
 
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -57,7 +58,7 @@ public class SskpBahnsteigUtils {
 			this(OptionalDouble.of(start.doubleValue()),
 					OptionalDouble.of(end.doubleValue()));
 		}
-		
+
 		public OptionalDouble getDistanceStart() {
 			return distanceStart;
 		}
@@ -90,7 +91,7 @@ public class SskpBahnsteigUtils {
 		final Punkt_Objekt_TOP_Kante_AttributeGroup potk = getSinglePoint(pzb);
 		final boolean searchDirection = !isWirkrichtungTopDirection(potk);
 
-		final Optional<Range<Double>> reduce = Streams.stream(bahnsteig)
+		final Optional<Range<BigDecimal>> reduce = Streams.stream(bahnsteig)
 				.map(bsk -> PunktObjektExtensions.distanceToBereichObjekt(pzb,
 						bsk, searchDirection))
 				.filter(Optional::isPresent).map(Optional::get)
@@ -99,8 +100,8 @@ public class SskpBahnsteigUtils {
 			return new BahnsteigDistance(OptionalDouble.empty(),
 					OptionalDouble.empty());
 		}
-		return new BahnsteigDistance(reduce.get().upperEndpoint(),
-				reduce.get().lowerEndpoint());
+		return new BahnsteigDistance(reduce.get().upperEndpoint().doubleValue(),
+				reduce.get().lowerEndpoint().doubleValue());
 	}
 
 	private static BahnsteigDistance getBahnsteigDistanceAtMagnet(

--- a/java/bundles/org.eclipse.set.feature.table.pt1/src/org/eclipse/set/feature/table/pt1/ssza/SszaTransformator.xtend
+++ b/java/bundles/org.eclipse.set.feature.table.pt1/src/org/eclipse/set/feature/table/pt1/ssza/SszaTransformator.xtend
@@ -4,7 +4,7 @@
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0.
- *
+ * 
  * SPDX-License-Identifier: EPL-2.0
  * 
  */

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/BereichObjektExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/BereichObjektExtensions.xtend
@@ -282,26 +282,27 @@ class BereichObjektExtensions extends BasisObjektExtensions {
 			return false
 		}
 
-		val tA = teilbereich.begrenzungA.wert.doubleValue
-		val tB = teilbereich.begrenzungB.wert.doubleValue
-		val oA = other.begrenzungA.wert.doubleValue
-		val oB = other.begrenzungB.wert.doubleValue
+		val tA = teilbereich.begrenzungA.wert
+		val tB = teilbereich.begrenzungB.wert
+		val oA = other.begrenzungA.wert
+		val oB = other.begrenzungB.wert
 
 		return intersects(tA, tB, oA, oB)
 	}
 
-	protected def static boolean intersects(double a1, double a2, double b1,
-		double b2) {
-		Assert.isTrue(Distance.compare(a1, a2) <= 0)
-		Assert.isTrue(Distance.compare(b1, b2) <= 0)
+	protected def static boolean intersects(BigDecimal a1, BigDecimal a2, BigDecimal b1,
+		BigDecimal b2) {
+		val distance = new Distance()
+		Assert.isTrue(distance.compare(a1, a2) <= 0)
+		Assert.isTrue(distance.compare(b1, b2) <= 0)
 
 		// [a1,a2] < [b1,b2]
-		if (Distance.compare(a2, b1) < 0) {
+		if (distance.compare(a2, b1) < 0) {
 			return false
 		}
 
 		// [b1,b2] < [a1,a2]
-		if (Distance.compare(b2, a1) < 0) {
+		if (distance.compare(b2, a1) < 0) {
 			return false
 		}
 
@@ -356,27 +357,28 @@ class BereichObjektExtensions extends BasisObjektExtensions {
 			return false
 		}
 
-		val tA = teilbereich.begrenzungA.wert.doubleValue
-		val tB = teilbereich.begrenzungB.wert.doubleValue
-		val oA = other.begrenzungA.wert.doubleValue
-		val oB = other.begrenzungB.wert.doubleValue
+		val tA = teilbereich.begrenzungA.wert
+		val tB = teilbereich.begrenzungB.wert
+		val oA = other.begrenzungA.wert
+		val oB = other.begrenzungB.wert
 
 		return intersectsStrictly(tA, tB, oA, oB)
 	}
 
-	protected def static boolean intersectsStrictly(double a1, double a2,
-		double b1, double b2) {
-		Assert.isTrue(Distance.compare(a1, a2) <= 0)
-		Assert.isTrue(Distance.compare(b1, b2) <= 0)
+	protected def static boolean intersectsStrictly(BigDecimal a1, BigDecimal a2,
+		BigDecimal b1, BigDecimal b2) {
+			val distance = new Distance()
+		Assert.isTrue(distance.compare(a1, a2) <= 0)
+		Assert.isTrue(distance.compare(b1, b2) <= 0)
 
 		// If the second tb starts after the first tb ends, there is no intersection
-		val aEndBStart = Distance.compare(a2, b1)
+		val aEndBStart = distance.compare(a2, b1)
 		if (aEndBStart < 0) {
 			return false
 		}
 
 		// If the first tb starts after the second tb ends, there is no intersection
-		val bEndAStart = Distance.compare(b2, a1)
+		val bEndAStart = distance.compare(b2, a1)
 		if (bEndAStart < 0) {
 			return false
 		}
@@ -514,19 +516,19 @@ class BereichObjektExtensions extends BasisObjektExtensions {
 	) {
 		val sameTopKante = teilbereich.IDTOPKante?.wert ==
 			singlePoint.IDTOPKante?.wert
-
+		val distance = new Distance()
 		if (sameTopKante) {
-			val A = teilbereich.begrenzungA.wert.doubleValue
-			val B = teilbereich.begrenzungB.wert.doubleValue
+			val A = teilbereich.begrenzungA.wert
+			val B = teilbereich.begrenzungB.wert
 
-			if (Distance.compare(A, B) > 0) {
+			if (distance.compare(A, B) > 0) {
 				throw new IllegalArgumentException('''Teilbereich with Begrenzungen A=«A» B=«B»''')
 			}
 
-			val abstand = singlePoint.abstand.wert.doubleValue
+			val abstand = singlePoint.abstand.wert
 
-			return Distance.compare(A, abstand) <= 0 &&
-				Distance.compare(abstand, B) <= 0
+			return distance.compare(A, abstand) <= 0 &&
+				distance.compare(abstand, B) <= 0
 		}
 
 		return false
@@ -545,6 +547,7 @@ class BereichObjektExtensions extends BasisObjektExtensions {
 		Punkt_Objekt_TOP_Kante_AttributeGroup singlePoint,
 		double tolerant
 	) {
+		val tolerantBigDecimal = BigDecimal.valueOf(tolerant)
 		val teilBereichTopKante = teilbereich.IDTOPKante?.value
 		// The point should lie on the TOP_Kante of teilbereich 
 		// or the connect TOP_Kanten of this TOP_Kante
@@ -560,36 +563,36 @@ class BereichObjektExtensions extends BasisObjektExtensions {
 		}
 		val clone = EcoreUtil.copy(teilbereich)
 
-		val A = teilbereich.begrenzungA.wert.doubleValue
-		val B = teilbereich.begrenzungB.wert.doubleValue
-		val topKanteRange = Range.of(0.0, teilBereichTopKante.laenge)
+		val A = teilbereich.begrenzungA.wert
+		val B = teilbereich.begrenzungB.wert
+		val topKanteRange = Range.of(BigDecimal.ZERO, teilBereichTopKante.laenge)
 		val sameTopKante = teilbereich.IDTOPKante?.wert ==
 			singlePoint.IDTOPKante?.wert
 		if (sameTopKante) {
-			if (A === 0 && B === teilBereichTopKante.laenge) {
+			if (A === BigDecimal.ZERO && B === teilBereichTopKante.laenge) {
 				throw new IllegalArgumentException('''The TOP_Kante: «teilbereich.IDTOPKante.wert» should contain the Punkt_Objekt: «singlePoint.identitaet»''')
 			}
 
-			clone.begrenzungA.wert = BigDecimal.valueOf(
+			clone.begrenzungA.wert = 
 				topKanteRange.isStartedBy(A)
 					? A
-					: topKanteRange.fit(A - tolerant))
-			clone.begrenzungB.wert = BigDecimal.valueOf(
+					: topKanteRange.fit(A - tolerantBigDecimal)
+			clone.begrenzungB.wert = 
 				topKanteRange.isEndedBy(B) ? B : topKanteRange.fit(A +
-					tolerant))
+					tolerantBigDecimal)
 			return clone.contains(singlePoint)
 		}
 
 		// When the point and the teilbereich not in same TopKante,
 		// then the teilbereich with tolerant muss out of topkante range
-		if (topKanteRange.contains(A - tolerant) &&
-			topKanteRange.contains(B + tolerant)) {
+		if (topKanteRange.contains(A - tolerantBigDecimal) &&
+			topKanteRange.contains(B + tolerantBigDecimal)) {
 			return false
 		}
 		val tolerantDistanceFromA = topKanteRange.
-				isStartedBy(A) ? tolerant : tolerant - A
+				isStartedBy(A) ? tolerantBigDecimal : tolerantBigDecimal - A
 		val tolerantDistanceFromB = topKanteRange.
-				isEndedBy(B) ? tolerant : (tolerant + B) - topKanteRange.maximum
+				isEndedBy(B) ? tolerantBigDecimal : (tolerantBigDecimal + B) - topKanteRange.maximum
 		return teilbereich.containsWithinTolerant(singlePoint,
 			teilBereichTopKante.TOPKnotenA, tolerantDistanceFromA) ||
 			teilbereich.containsWithinTolerant(singlePoint,
@@ -599,7 +602,7 @@ class BereichObjektExtensions extends BasisObjektExtensions {
 	private def static boolean containsWithinTolerant(
 		Bereich_Objekt_Teilbereich_AttributeGroup botb,
 		Punkt_Objekt_TOP_Kante_AttributeGroup singlePoint, TOP_Knoten topKnote,
-		double tolerant) {
+		BigDecimal tolerant) {
 		val targetTopKante = topKnote.topKanten.findFirst [
 			it !== botb.topKante && it === singlePoint.IDTOPKante?.value
 		]
@@ -673,14 +676,14 @@ class BereichObjektExtensions extends BasisObjektExtensions {
 		if (tTopKante.identitaet.wert != eTopKante.identitaet.wert) {
 			return false
 		}
-		val tA = teilbereich.begrenzungA.wert.doubleValue
-		val tB = teilbereich.begrenzungB.wert.doubleValue
+		val tA = teilbereich.begrenzungA.wert
+		val tB = teilbereich.begrenzungB.wert
 		Assert.isNotNull(start)
 		Assert.isNotNull(end)
 		val aStart = eTopKante.getAbstand(start)
 		val aEnd = eTopKante.getAbstand(end)
-		val eA = Math.min(aStart, aEnd)
-		val eB = Math.max(aStart, aEnd)
+		val eA = aStart.min(aEnd)
+		val eB = aStart.max(aEnd)
 		return intersects(tA, tB, eA, eB)
 	}
 
@@ -694,16 +697,16 @@ class BereichObjektExtensions extends BasisObjektExtensions {
 		if (tTopKante?.wert != eTopKante.identitaet.wert) {
 			return false
 		}
-		val tA = teilbereich.begrenzungA.wert.doubleValue
-		val tB = teilbereich.begrenzungB.wert.doubleValue
+		val tA = teilbereich.begrenzungA.wert
+		val tB = teilbereich.begrenzungB.wert
 		Assert.isNotNull(start)
 		val aStart = eTopKante.getAbstand(start)
 		var aEnd = eTopKante.laenge
 		if (!edge.forwards) {
-			aEnd = 0.0
+			aEnd = BigDecimal.ZERO
 		}
-		val eA = Math.min(aStart, aEnd)
-		val eB = Math.max(aStart, aEnd)
+		val eA = aStart.min(aEnd)
+		val eB = aStart.max(aEnd)
 		return intersects(tA, tB, eA, eB)
 	}
 
@@ -717,16 +720,16 @@ class BereichObjektExtensions extends BasisObjektExtensions {
 		if (tTopKante?.wert != eTopKante.identitaet.wert) {
 			return false
 		}
-		val tA = teilbereich.begrenzungA.wert.doubleValue
-		val tB = teilbereich.begrenzungB.wert.doubleValue
+		val tA = teilbereich.begrenzungA.wert
+		val tB = teilbereich.begrenzungB.wert
 		Assert.isNotNull(end)
-		var aStart = 0.0
+		var aStart = BigDecimal.ZERO
 		if (!edge.forwards) {
 			aStart = eTopKante.laenge
 		}
 		val aEnd = eTopKante.getAbstand(end)
-		val eA = Math.min(aStart, aEnd)
-		val eB = Math.max(aStart, aEnd)
+		val eA = aStart.min(aEnd)
+		val eB = aStart.max(aEnd)
 		return intersects(tA, tB, eA, eB)
 	}
 
@@ -753,12 +756,12 @@ class BereichObjektExtensions extends BasisObjektExtensions {
 	) {
 		if (teilbereich.IDTOPKante?.wert != topKante.identitaet.wert)
 			return false;
-
-		val A = teilbereich.begrenzungA.wert.doubleValue
-		val B = teilbereich.begrenzungB.wert.doubleValue
-
-		return Distance.compare(A, distance) <= 0 &&
-			Distance.compare(distance, B) <= 0
+		val comparator = new Distance()
+		val A = teilbereich.begrenzungA.wert
+		val B = teilbereich.begrenzungB.wert
+		val toBigDecimal = BigDecimal.valueOf(distance)
+		return comparator.compare(A, toBigDecimal) <= 0 &&
+			comparator.compare(toBigDecimal, B) <= 0
 	}
 
 	def static BigDecimal getOverlappingLength(Bereich_Objekt bo,

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/GeoKanteExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/GeoKanteExtensions.xtend
@@ -8,6 +8,7 @@
  */
 package org.eclipse.set.ppmodel.extensions
 
+import java.math.BigDecimal
 import java.util.ArrayList
 import java.util.List
 import org.eclipse.set.basis.geometry.Chord
@@ -33,6 +34,8 @@ import org.slf4j.LoggerFactory
 import static extension org.eclipse.set.ppmodel.extensions.GeoKnotenExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.geometry.GEOKanteGeometryExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.utils.LineStringExtensions.*
+import org.eclipse.set.basis.constants.ToolboxConstants
+import java.math.RoundingMode
 
 /**
  * This class extends {@link GEO_Kante}.
@@ -47,19 +50,19 @@ class GeoKanteExtensions extends BasisObjektExtensions {
 	def static GeoPosition getCoordinate(
 		GEO_Kante geoKante,
 		GEO_Knoten startGeoKnoten,
-		double abstand,
-		double seitlicherAbstand,
+		BigDecimal abstand,
+		BigDecimal seitlicherAbstand,
 		ENUMWirkrichtung wirkrichtung
 	) {
 		val geometry = geoKante.getGeometry
 		// If the geometry size is smaller than the GEO_Laenge of the GEO_Kante
 		// adjust the distance to fit within the GEO_Kante
-		val edgeLength = Math.abs(
-			geoKante.GEOKanteAllg.GEOLaenge.wert.doubleValue)
+		val edgeLength =
+			geoKante.GEOKanteAllg?.GEOLaenge?.wert?.abs
 		var distance = abstand
-		val geoLength = geometry.length
+		val geoLength = BigDecimal.valueOf(geometry.length)
 		if (geoLength < edgeLength) {
-			distance = abstand * (geoLength / edgeLength)
+			distance = abstand * (geoLength.divide(edgeLength, ToolboxConstants.ROUNDING_TO_PLACE, RoundingMode.HALF_UP))
 		}
 		val SegmentPosition position = Geometries.getSegmentPosition(
 			geometry, startGeoKnoten.coordinate, distance)
@@ -72,7 +75,7 @@ class GeoKanteExtensions extends BasisObjektExtensions {
 	def static GeoPosition getCoordinate(
 		LineSegment tangent,
 		SegmentPosition position,
-		double seitlicherAbstand,
+		BigDecimal seitlicherAbstand,
 		ENUMWirkrichtung wirkrichtung
 	) {
 		val LineSegment lateralSegement = Geometries.clone(tangent)
@@ -82,13 +85,13 @@ class GeoKanteExtensions extends BasisObjektExtensions {
 				
 			
 		var double angle
-		if (seitlicherAbstand < 0) {
+		if (seitlicherAbstand.doubleValue < 0) {
 			angle = 90
 		} else {
 			angle = -90
 		}
 		Geometries.turn(lateralSegement, angle)
-		Geometries.scale(lateralSegement, Math.abs(seitlicherAbstand))
+		Geometries.scale(lateralSegement, seitlicherAbstand.abs.doubleValue)
 
 		// direction
 		val DirectedElement<LineSegment> directedLineSegment = position.

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/GeoKnotenExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/GeoKnotenExtensions.xtend
@@ -9,7 +9,9 @@
 package org.eclipse.set.ppmodel.extensions
 
 import com.google.common.base.Predicate
+import java.math.BigDecimal
 import java.util.List
+import java.util.Set
 import org.eclipse.set.basis.Lists
 import org.eclipse.set.basis.geometry.GeoPosition
 import org.eclipse.set.basis.geometry.GeometryException
@@ -24,12 +26,12 @@ import org.locationtech.jts.geom.Coordinate
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+import static java.math.BigDecimal.ZERO
 import static org.eclipse.set.ppmodel.extensions.utils.Debug.*
 
 import static extension org.eclipse.set.ppmodel.extensions.GeoKanteExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.GeoPunktExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.utils.CollectionExtensions.*
-import java.util.Set
 
 /**
  * This class extends {@link GEO_Knoten}.
@@ -120,8 +122,8 @@ class GeoKnotenExtensions extends BasisObjektExtensions {
 		GEO_Knoten startGeoKnoten,
 		GEO_Kante lastGeoKante,
 		Basis_Objekt parentEdge,
-		double abstand,
-		double seitlicherAbstand,
+		BigDecimal abstand,
+		BigDecimal seitlicherAbstand,
 		ENUMWirkrichtung wirkrichtung
 	) {
 		// Betrachtung Startpunkt
@@ -158,8 +160,8 @@ class GeoKnotenExtensions extends BasisObjektExtensions {
 		GEO_Kante lastGeoKante,
 		List<GEO_Kante> geoKantenOnStart,
 		Basis_Objekt parentEdge,
-		double abstand,
-		double seitlicherAbstand,
+		BigDecimal abstand,
+		BigDecimal seitlicherAbstand,
 		ENUMWirkrichtung wirkrichtung
 	) {
 		geoKantenOnStart.remove(lastGeoKante); // don't go back
@@ -168,14 +170,14 @@ class GeoKnotenExtensions extends BasisObjektExtensions {
 			logger.debug("TOP Kante/Strecke: {}", debugString(parentEdge))
 			logger.debug("Last GEO Kante: {}", debugString(lastGeoKante))
 			logger.debug("Next GEO Kanten: {}", debugString(geoKantenOnStart))
-			logger.debug("Abstand: {}", Double.valueOf(abstand))
+			logger.debug("Abstand: {}", abstand)
 			throw new GeometryException(
 				String.format("No GEO Kanten continuation at %s",
 					startGeoKnoten.getIdentitaet().getWert()))
 		}
 		val GEO_Kante geoKante = geoKantenOnStart.get(0)
-		val double geoKanteLength = geoKante.GEOKanteAllg.GEOLaenge.wert.
-			doubleValue
+		val BigDecimal geoKanteLength = geoKante.GEOKanteAllg.GEOLaenge.wert
+			
 		if (abstand <= geoKanteLength) {
 			return geoKante.getCoordinate(startGeoKnoten, abstand,
 				seitlicherAbstand, wirkrichtung);
@@ -194,21 +196,21 @@ class GeoKnotenExtensions extends BasisObjektExtensions {
 	 * @param startGeoKnoten the GEO_Knoten to start from
 	 * @param topKante the TOP_Kante to consider GEO_Kanten from
 	 */
-	def static Iterable<Pair<GEO_Kante, Double>> getGeoKantenWithDistance(
+	def static Iterable<Pair<GEO_Kante, BigDecimal>> getGeoKantenWithDistance(
 		GEO_Knoten startGeoKnoten,
 		TOP_Kante topKante
 	) {
 		val geoKanten = topKante.container.GEOKante.filter [ k |
 			k.topKante == topKante
 		].toList
-		return getGeoKantenWithDistance(startGeoKnoten, null, geoKanten, 0)
+		return getGeoKantenWithDistance(startGeoKnoten, null, geoKanten, ZERO)
 	}
 
-	private def static Iterable<Pair<GEO_Kante, Double>> getGeoKantenWithDistance(
+	private def static Iterable<Pair<GEO_Kante, BigDecimal>> getGeoKantenWithDistance(
 		GEO_Knoten startGeoKnoten,
 		GEO_Kante lastGeoKante,
 		List<GEO_Kante> geoKanten,
-		double distance
+		BigDecimal distance
 	) {
 		// Remove previous node
 		geoKanten.remove(lastGeoKante)
@@ -229,8 +231,7 @@ class GeoKnotenExtensions extends BasisObjektExtensions {
 					startGeoKnoten.getIdentitaet().getWert()))
 		}
 		val GEO_Kante geoKante = edges.get(0)
-		val double geoKanteLength = geoKante.GEOKanteAllg.GEOLaenge.wert.
-			doubleValue
+		val BigDecimal geoKanteLength = geoKante.GEOKanteAllg.GEOLaenge.wert
 
 		return #[geoKante -> distance] +
 			geoKante.getOpposite(startGeoKnoten).getGeoKantenWithDistance(

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/PunktObjektExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/PunktObjektExtensions.xtend
@@ -9,6 +9,7 @@
 package org.eclipse.set.ppmodel.extensions
 
 import com.google.common.collect.Range
+import java.math.BigDecimal
 import java.util.List
 import java.util.Optional
 import org.eclipse.set.basis.graph.DirectedEdge
@@ -16,6 +17,7 @@ import org.eclipse.set.basis.graph.TopPoint
 import org.eclipse.set.core.services.Services
 import org.eclipse.set.model.planpro.BasisTypen.ENUMWirkrichtung
 import org.eclipse.set.model.planpro.Basisobjekte.Bereich_Objekt
+import org.eclipse.set.model.planpro.Basisobjekte.Bereich_Objekt_Teilbereich_AttributeGroup
 import org.eclipse.set.model.planpro.Basisobjekte.Punkt_Objekt
 import org.eclipse.set.model.planpro.Basisobjekte.Punkt_Objekt_TOP_Kante_AttributeGroup
 import org.eclipse.set.model.planpro.Geodaten.Strecke
@@ -31,7 +33,6 @@ import static extension org.eclipse.set.ppmodel.extensions.ENUMWirkrichtungExten
 import static extension org.eclipse.set.ppmodel.extensions.PunktObjektTopKanteExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.SignalExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.utils.CollectionExtensions.*
-import org.eclipse.set.model.planpro.Basisobjekte.Bereich_Objekt_Teilbereich_AttributeGroup
 
 /**
  * This class extends {@link Punkt_Objekt}.
@@ -171,46 +172,46 @@ class PunktObjektExtensions extends BasisObjektExtensions {
 		return po.punktObjektStrecke.map[IDStrecke?.value].filterNull.toList
 	}
 
-	def static Optional<Range<Double>> distanceToBereichObjekt(Punkt_Objekt po,
+	def static Optional<Range<BigDecimal>> distanceToBereichObjekt(Punkt_Objekt po,
 		Bereich_Objekt bo) {
 		return distanceToBereichObjekt(po, bo, Optional.empty)
 	}
 
-	def static Optional<Range<Double>> distanceToBereichObjekt(Punkt_Objekt po,
+	def static Optional<Range<BigDecimal>> distanceToBereichObjekt(Punkt_Objekt po,
 		Bereich_Objekt bo, boolean inDirection) {
 		return distanceToBereichObjekt(po, bo,
 			Optional.of(Boolean.valueOf(inDirection)))
 	}
 
-	private def static Optional<Range<Double>> distanceToBereichObjekt(
+	private def static Optional<Range<BigDecimal>> distanceToBereichObjekt(
 		Punkt_Objekt po, Bereich_Objekt bo, Optional<Boolean> inDirection) {
 		if (bo.contains(po)) {
-			return Optional.of(Range.singleton(0.0))
+			return Optional.of(Range.singleton(BigDecimal.ZERO))
 		}
 		val poTopPoint = new TopPoint(po)
 		val boTopPoints = bo.toTopPoints.flatten
-		val doubleValues = boTopPoints.map [ point |
+		val shortestDistances = boTopPoints.map [ point |
 			inDirection.isEmpty
 				? Services.topGraphService.
 				findShortestDistance(poTopPoint, point)
 				: Services.topGraphService.
 				findShortestDistanceInDirection(poTopPoint, point,
 					inDirection.get.booleanValue)
-		].filter[isPresent].map[get.doubleValue]
-		if (doubleValues.isNullOrEmpty) {
+		].filter[isPresent].map[get]
+		if (shortestDistances.isNullOrEmpty) {
 			return Optional.empty
 		}
-		return Optional.of(Range.closed(doubleValues.min, doubleValues.max))
+		return Optional.of(Range.closed(shortestDistances.min, shortestDistances.max))
 	}
 	
-	def static Range<Double> distanceToTeilBereichObjekt(Punkt_Objekt po, Bereich_Objekt_Teilbereich_AttributeGroup botb) {
+	def static Range<BigDecimal> distanceToTeilBereichObjekt(Punkt_Objekt po, Bereich_Objekt_Teilbereich_AttributeGroup botb) {
 		if (botb.contains(po.singlePoint)) {
-			return Range.singleton(0.0);
+			return Range.singleton(BigDecimal.ZERO);
 		}
 		val poTopPoint = new TopPoint(po)
 		val distances = botb.toTopPoints.map[
 			Services.topGraphService.findShortestDistance(poTopPoint, it)
-		].filter[isPresent].map[get.doubleValue]
+		].filter[isPresent].map[get]
 		
 		if (distances.isNullOrEmpty) {
 			return null

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/PunktObjektTopKanteExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/PunktObjektTopKanteExtensions.xtend
@@ -74,9 +74,9 @@ class PunktObjektTopKanteExtensions extends BasisObjektExtensions {
 		ENUMWirkrichtung direction
 	) {
 		val topKante = singlePoint.topKante
-		val abstand = singlePoint.abstand.wert.doubleValue
-		val lateralDistance = (singlePoint?.seitlicherAbstand?.wert ?:
-			BigDecimal.ZERO).doubleValue
+		val abstand = singlePoint.abstand.wert
+		val lateralDistance = singlePoint?.seitlicherAbstand?.wert ?:
+			BigDecimal.ZERO
 		return topKante.getCoordinate(abstand, lateralDistance, direction)
 	}
 
@@ -100,6 +100,7 @@ class PunktObjektTopKanteExtensions extends BasisObjektExtensions {
 	def static Set<TOP_Knoten> getTopKnoten(
 		Punkt_Objekt_TOP_Kante_AttributeGroup singlePoint
 	) {
+		val comparator = new Distance()
 		val result = new HashSet
 
 		val topKante = singlePoint.topKante
@@ -107,13 +108,13 @@ class PunktObjektTopKanteExtensions extends BasisObjektExtensions {
 			return result
 		}
 		val abstand = topKante.getAbstand(singlePoint)
-		val length = topKante.TOPKanteAllg.TOPLaenge.wert.doubleValue
+		val length = topKante.TOPKanteAllg.TOPLaenge.wert
 
-		if (Distance.compare(abstand, 0) == 0) {
+		if (comparator.compare(abstand, BigDecimal.ZERO) == 0) {
 			result.add(topKante.TOPKnotenA)
 		}
 
-		if (Distance.compare(abstand, length) == 0) {
+		if (comparator.compare(abstand, length) == 0) {
 			result.add(topKante.TOPKnotenB)
 		}
 
@@ -151,12 +152,12 @@ class PunktObjektTopKanteExtensions extends BasisObjektExtensions {
 		Punkt_Objekt_TOP_Kante_AttributeGroup singlePoint
 	) {
 		val topKante = singlePoint.topKante
-		val abstand = singlePoint.abstand.wert.doubleValue
+		val abstand = singlePoint.abstand.wert
 		val wirkrichtung = singlePoint.wirkrichtung?.wert
 
 		// Determine two coordinates, each with an offset of 1 unit to the TOP_Kante 
-		val firstCoordinate = topKante.getCoordinate(abstand, -1, wirkrichtung)
-		val secondCoordinate = topKante.getCoordinate(abstand, 1, wirkrichtung)
+		val firstCoordinate = topKante.getCoordinate(abstand, BigDecimal.ONE.negate, wirkrichtung)
+		val secondCoordinate = topKante.getCoordinate(abstand, BigDecimal.ONE, wirkrichtung)
 
 		return firstCoordinate -> secondCoordinate
 	}

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/SignalExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/SignalExtensions.xtend
@@ -8,6 +8,7 @@
  */
 package org.eclipse.set.ppmodel.extensions
 
+import java.math.BigDecimal
 import java.util.Collections
 import java.util.List
 import java.util.Set
@@ -26,6 +27,7 @@ import org.eclipse.set.model.planpro.Ortung.FMA_Komponente
 import org.eclipse.set.model.planpro.Ortung.Schaltmittel_Zuordnung
 import org.eclipse.set.model.planpro.Signalbegriffe_Ril_301.Zs3v
 import org.eclipse.set.model.planpro.Signalbegriffe_Struktur.Signalbegriff_ID_TypeClass
+import org.eclipse.set.model.planpro.Signale.ENUMFiktivesSignalFunktion
 import org.eclipse.set.model.planpro.Signale.Signal
 import org.eclipse.set.model.planpro.Signale.Signal_Befestigung
 import org.eclipse.set.model.planpro.Signale.Signal_Rahmen
@@ -55,7 +57,6 @@ import static extension org.eclipse.set.ppmodel.extensions.StellelementExtension
 import static extension org.eclipse.set.ppmodel.extensions.TopKanteExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.utils.CollectionExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.utils.Debug.*
-import org.eclipse.set.model.planpro.Signale.ENUMFiktivesSignalFunktion
 
 /**
  * This class extends {@link Signal}.
@@ -64,7 +65,7 @@ class SignalExtensions extends PunktObjektExtensions {
 
 	static val Logger logger = LoggerFactory.getLogger(typeof(SignalExtensions))
 
-	static val double ABSTAND_VORSIGNALBAKE = 260
+	static val BigDecimal ABSTAND_VORSIGNALBAKE = BigDecimal.valueOf(260)
 
 	static val String PREFIX_VORSIGNALBAKE = "Ne3"
 

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/StreckeExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/StreckeExtensions.xtend
@@ -8,6 +8,7 @@
  */
 package org.eclipse.set.ppmodel.extensions
 
+import java.math.BigDecimal
 import org.eclipse.set.basis.geometry.GeoPosition
 import org.eclipse.set.model.planpro.BasisTypen.ENUMWirkrichtung
 import org.eclipse.set.model.planpro.Geodaten.GEO_Kante
@@ -46,7 +47,7 @@ class StreckeExtensions extends BasisObjektExtensions {
 	}
 
 	def static GeoPosition getKilometerCoordinate(Strecke strecke,
-		double kilometer) {
+		BigDecimal meter) {
 
 		val startEnd = strecke.startEnd
 		if (startEnd === null)
@@ -57,8 +58,8 @@ class StreckeExtensions extends BasisObjektExtensions {
 		return start.geoKnoten.getCoordinate(
 			null,
 			strecke,
-			kilometer - start.streckeMeter.wert,
-			0,
+			meter - start.streckeMeter.wert,
+			BigDecimal.ZERO,
 			ENUMWirkrichtung.ENUM_WIRKRICHTUNG_IN
 		)
 	}

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/TopKnotenExtensions.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/TopKnotenExtensions.xtend
@@ -8,22 +8,24 @@
  */
 package org.eclipse.set.ppmodel.extensions
 
-import org.eclipse.set.ppmodel.extensions.utils.Distance
+import java.math.BigDecimal
+import java.util.List
 import org.eclipse.set.model.planpro.Basisobjekte.Punkt_Objekt
 import org.eclipse.set.model.planpro.Geodaten.GEO_Knoten
 import org.eclipse.set.model.planpro.Geodaten.TOP_Kante
 import org.eclipse.set.model.planpro.Geodaten.TOP_Knoten
 import org.eclipse.set.model.planpro.Weichen_und_Gleissperren.W_Kr_Gsp_Element
 import org.eclipse.set.model.planpro.Weichen_und_Gleissperren.W_Kr_Gsp_Komponente
-import java.util.List
+import org.eclipse.set.ppmodel.extensions.utils.Distance
+import org.locationtech.jts.geom.Coordinate
 
 import static org.eclipse.set.model.planpro.Geodaten.ENUMTOPAnschluss.*
 
+import static extension org.eclipse.set.ppmodel.extensions.GeoKnotenExtensions.*
+import static extension org.eclipse.set.ppmodel.extensions.PunktObjektExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.PunktObjektTopKanteExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.TopKanteExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.WKrGspKomponenteExtensions.*
-import static extension org.eclipse.set.ppmodel.extensions.GeoKnotenExtensions.*
-import org.locationtech.jts.geom.Coordinate
 
 /**
  * Diese Klasse erweitert {@link TOP_Knoten}.
@@ -89,18 +91,18 @@ class TopKnotenExtensions extends BasisObjektExtensions {
 		}
 		val singlePoint = singlePoints.get(0)
 		val topKante = singlePoint.topKante
-
+		val comparator = new Distance()
 		if (topKante.IDTOPKnotenA?.wert ==
 			topKnoten.identitaet.wert) {
-			return Distance.compare(0, singlePoint.abstand.wert.doubleValue) ==
+			return comparator.compare(BigDecimal.ZERO, singlePoint.abstand.wert) ==
 				0
 		}
 
 		if (topKante.IDTOPKnotenB?.wert ==
 			topKnoten.identitaet.wert) {
-			return Distance.compare(
-				topKante.TOPKanteAllg.TOPLaenge.wert.doubleValue,
-				singlePoint.abstand.wert.doubleValue
+			return comparator.compare(
+				topKante.TOPKanteAllg.TOPLaenge.wert,
+				singlePoint.abstand.wert
 			) == 0
 		}
 

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/internal/SinglePointIterator.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/internal/SinglePointIterator.xtend
@@ -50,7 +50,7 @@ class SinglePointIterator implements Iterator<Punkt_Objekt_TOP_Kante_AttributeGr
 			val d1 = edge.distanceFromTail(o1)
 			val d2 = edge.distanceFromTail(o2)
 
-			return Distance.compare(d1, d2)
+			return new Distance().compare(d1, d2)
 		}
 	}
 

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/DirectedTopKante.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/DirectedTopKante.xtend
@@ -68,7 +68,7 @@ class DirectedTopKante extends DirectedElementImpl<TOP_Kante> implements Directe
 		Punkt_Objekt_TOP_Kante_AttributeGroup end) {
 		val abstandStart = topKante.getAbstand(start)
 		val abstandEnd = topKante.getAbstand(end)
-		return Distance.compare(abstandStart, abstandEnd) <= 0
+		return new Distance().compare(abstandStart, abstandEnd) <= 0
 	}
 
 	override contains(Punkt_Objekt_TOP_Kante_AttributeGroup singlePoint) {

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/Distance.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/Distance.xtend
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2016 DB Netz AG and others.
- *
+ * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,28 +9,29 @@
 package org.eclipse.set.ppmodel.extensions.utils
 
 import java.util.Comparator
+import java.math.BigDecimal
 
 /**
  * This class can compare Abstand values.
  * 
  * @author Schaefer
  */
-class Distance implements Comparator<Double> {
-	
+class Distance implements Comparator<BigDecimal> {
+
 	static val double TOLERANCE = 0.1
-	
+
 	/**
 	 * Compares Abstand values with a given tolerance.
 	 * 
 	 * @param a first Abstand
 	 * @param b second Abstand
 	 * 
-     * @return a negative integer, zero, or a positive integer as the
-     * first Abstand is less than, equal to, or greater than the
-     * second.
+	 * @return a negative integer, zero, or a positive integer as the
+	 * first Abstand is less than, equal to, or greater than the
+	 * second.
 	 */
-	def static int compare(double a, double b) {
-		if (Math.abs(a - b) <= TOLERANCE) {
+	override compare(BigDecimal a, BigDecimal b) {
+		if ((a - b).abs.compareTo(BigDecimal.valueOf(TOLERANCE)) <= 0) {
 			return 0
 		}
 		if (a < b) {
@@ -38,8 +39,5 @@ class Distance implements Comparator<Double> {
 		}
 		return 1
 	}
-	
-	override compare(Double o1, Double o2) {
-		return compare(o1.doubleValue, o2.doubleValue)
-	}
+
 }

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/TeilFahrweg.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/TeilFahrweg.xtend
@@ -8,20 +8,21 @@
  */
 package org.eclipse.set.ppmodel.extensions.utils
 
+import java.math.BigDecimal
+import java.util.LinkedList
+import java.util.List
+import org.eclipse.core.runtime.Assert
 import org.eclipse.set.model.planpro.Basisobjekte.Bereich_Objekt
 import org.eclipse.set.model.planpro.Basisobjekte.Bereich_Objekt_Teilbereich_AttributeGroup
 import org.eclipse.set.model.planpro.Basisobjekte.Punkt_Objekt
 import org.eclipse.set.model.planpro.Fahrstrasse.Fstr_Fahrweg
 import org.eclipse.set.model.planpro.Geodaten.TOP_Kante
 import org.eclipse.set.ppmodel.extensions.exception.AreaNotContinuous
-import java.util.LinkedList
-import java.util.List
 
 import static extension org.eclipse.set.ppmodel.extensions.BereichObjektExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.PunktObjektExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.PunktObjektTopKanteExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.TopKanteExtensions.*
-import org.eclipse.core.runtime.Assert
 
 /**
  * A Teilfahrweg describes a continuous part of the Fahrweg starting and ending
@@ -43,9 +44,9 @@ class TeilFahrweg {
 
 	int endPosition
 
-	double startAbstand
+	BigDecimal startAbstand
 
-	double endAbstand
+	BigDecimal endAbstand
 
 	List<TOP_Kante> sortedTopKanten
 
@@ -83,7 +84,7 @@ class TeilFahrweg {
 		}
 	}
 
-	def double getAbstand(Punkt_Objekt punktObjekt, TOP_Kante topKante) {
+	def BigDecimal getAbstand(Punkt_Objekt punktObjekt, TOP_Kante topKante) {
 		val singlePoints = punktObjekt.singlePoints.filter [ p |
 			p.topKante == topKante
 		].toList
@@ -92,7 +93,7 @@ class TeilFahrweg {
 			// Punkt Objekt is on topKante
 			Assert.isTrue(singlePoints.size == 1)
 			val singlePoint = singlePoints.get(0)
-			return singlePoint.abstand.wert.doubleValue
+			return singlePoint.abstand.wert
 		}
 
 		// Punkt Objekt is on adjacent topKante
@@ -107,11 +108,11 @@ class TeilFahrweg {
 		val C = topKante.connectionTo(adjacentKante)
 
 		if (A == C) {
-			return 0.0
+			return BigDecimal.ZERO
 		}
 
 		if (B == C) {
-			return topKante.getTOPKanteAllg.getTOPLaenge.wert.doubleValue
+			return topKante.getTOPKanteAllg.getTOPLaenge.wert
 		}
 
 		throw new IllegalArgumentException
@@ -166,21 +167,21 @@ class TeilFahrweg {
 	 * @result the length of the intersection of this Teilfahrweg and the given
 	 * Bereich Objekt in m
 	 */
-	def double intersectionLength(Bereich_Objekt object) {
+	def BigDecimal intersectionLength(Bereich_Objekt object) {
 		val result = object.bereichObjektTeilbereich.fold(
-			0.0,
+			BigDecimal.ZERO,
 			[result, p|result + this.intersectionLength(p)]
 		)
 		return result
 	}
 
-	def double intersectionLength(
+	def BigDecimal intersectionLength(
 		Bereich_Objekt_Teilbereich_AttributeGroup portion) {
 		val topKante = portion.topKante
 		val portionPosition = getPosition(topKante)
 
 		if (portionPosition > startPosition && portionPosition < endPosition) {
-			return portion.length.doubleValue
+			return portion.length
 		}
 
 		if (portionPosition == startPosition &&
@@ -196,10 +197,10 @@ class TeilFahrweg {
 			return intersectionLengthOnEndEdge(portion)
 		}
 
-		return 0.0
+		return BigDecimal.ZERO
 	}
 
-	private def double intersectionLengthOnSingleEdge(
+	private def BigDecimal intersectionLengthOnSingleEdge(
 		Bereich_Objekt_Teilbereich_AttributeGroup portion
 	) {
 		val topKanteStart = sortedTopKanten.get(startPosition)
@@ -209,8 +210,8 @@ class TeilFahrweg {
 		Assert.isTrue(topKanteStart == topKanteEnd)
 		Assert.isTrue(topKanteStart == topKantePortion)
 
-		val begrenzungA = portion.begrenzungA.wert.doubleValue
-		val begrenzungB = portion.begrenzungB.wert.doubleValue
+		val begrenzungA = portion.begrenzungA.wert
+		val begrenzungB = portion.begrenzungB.wert
 
 		Assert.isTrue(begrenzungA <= begrenzungB)
 
@@ -222,13 +223,13 @@ class TeilFahrweg {
 			begrenzungB)
 	}
 
-	private def double intersectionLength(double a1, double a2, double b1,
-		double b2) {
+	private def BigDecimal intersectionLength(BigDecimal a1, BigDecimal a2, BigDecimal b1,
+		BigDecimal b2) {
 		Assert.isTrue(a1 <= a2)
 		Assert.isTrue(b1 <= b2)
 		if (b1 <= a1) {
 			if (b2 <= a1) {
-				return 0.0
+				return BigDecimal.ZERO
 			}
 			if (b2 <= a2) {
 				return b2 - a1
@@ -241,10 +242,10 @@ class TeilFahrweg {
 			}
 			return a2 - b1
 		}
-		return 0.0
+		return BigDecimal.ZERO
 	}
 
-	private def double intersectionLengthOnStartEdge(
+	private def BigDecimal intersectionLengthOnStartEdge(
 		Bereich_Objekt_Teilbereich_AttributeGroup portion
 	) {
 		val startTopKante = sortedTopKanten.get(startPosition)
@@ -255,8 +256,8 @@ class TeilFahrweg {
 
 		Assert.isNotNull(C)
 
-		val portionA = portion.begrenzungA.wert.doubleValue
-		val portionB = portion.begrenzungB.wert.doubleValue
+		val portionA = portion.begrenzungA.wert
+		val portionB = portion.begrenzungB.wert
 
 		Assert.isTrue(portionA <= portionB)
 
@@ -270,10 +271,10 @@ class TeilFahrweg {
 			return intersectionLengthLeft(startAbstand, portionA, portionB)
 		}
 
-		return 0.0
+		return BigDecimal.ZERO
 	}
 
-	private def double intersectionLengthOnEndEdge(
+	private def BigDecimal intersectionLengthOnEndEdge(
 		Bereich_Objekt_Teilbereich_AttributeGroup portion
 	) {
 		val endTopKante = sortedTopKanten.get(endPosition)
@@ -284,8 +285,8 @@ class TeilFahrweg {
 
 		Assert.isNotNull(C)
 
-		val portionA = portion.begrenzungA.wert.doubleValue
-		val portionB = portion.begrenzungB.wert.doubleValue
+		val portionA = portion.begrenzungA.wert
+		val portionB = portion.begrenzungB.wert
 
 		Assert.isTrue(portionA <= portionB)
 
@@ -299,26 +300,26 @@ class TeilFahrweg {
 			return intersectionLengthLeft(endAbstand, portionA, portionB)
 		}
 
-		return 0.0
+		return BigDecimal.ZERO
 	}
 
-	private def double intersectionLengthRight(double p, double a, double b) {
+	private def BigDecimal intersectionLengthRight(BigDecimal p, BigDecimal a, BigDecimal b) {
 		if (p <= a) {
 			return b - a
 		}
 		if (p <= b) {
 			return b - p
 		}
-		return 0.0
+		return BigDecimal.ZERO
 	}
 
-	private def double intersectionLengthLeft(double p, double a, double b) {
+	private def BigDecimal intersectionLengthLeft(BigDecimal p, BigDecimal a, BigDecimal b) {
 		if (b <= p) {
 			return b - a
 		}
 		if (a <= p) {
 			return p - a
 		}
-		return 0.0
+		return BigDecimal.ZERO
 	}
 }

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/TopGraph.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/TopGraph.xtend
@@ -8,15 +8,16 @@
  */
 package org.eclipse.set.ppmodel.extensions.utils
 
-import org.eclipse.set.model.planpro.Basisobjekte.Punkt_Objekt_TOP_Kante_AttributeGroup
-import org.eclipse.set.model.planpro.Geodaten.TOP_Kante
-import org.eclipse.set.model.planpro.Geodaten.TOP_Knoten
+import java.math.BigDecimal
 import java.util.Comparator
 import java.util.Set
 import org.eclipse.core.runtime.Assert
 import org.eclipse.set.basis.graph.AbstractRouting
 import org.eclipse.set.basis.graph.Digraph
 import org.eclipse.set.basis.graph.DirectedEdge
+import org.eclipse.set.model.planpro.Basisobjekte.Punkt_Objekt_TOP_Kante_AttributeGroup
+import org.eclipse.set.model.planpro.Geodaten.TOP_Kante
+import org.eclipse.set.model.planpro.Geodaten.TOP_Knoten
 import org.eclipse.set.ppmodel.extensions.TopKanteExtensions
 
 import static extension org.eclipse.set.ppmodel.extensions.TopKanteExtensions.*
@@ -79,9 +80,9 @@ class TopGraph extends AbstractRouting<TOP_Kante, TOP_Knoten, Punkt_Objekt_TOP_K
 	}
 
 	override getDistanceComparator() {
-		return new Comparator<Double>() {
-			override compare(Double d1, Double d2) {
-				return Distance.compare(d1, d2)
+		return new Comparator<BigDecimal>() {
+			override compare(BigDecimal d1, BigDecimal d2) {
+				return new Distance().compare(d1, d2)
 			}
 		}
 	}

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/TopKantePath.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/TopKantePath.xtend
@@ -8,10 +8,7 @@
  */
 package org.eclipse.set.ppmodel.extensions.utils
 
-import org.eclipse.set.model.planpro.Basisobjekte.Bereich_Objekt
-import org.eclipse.set.model.planpro.Basisobjekte.Punkt_Objekt_TOP_Kante_AttributeGroup
-import org.eclipse.set.model.planpro.Geodaten.TOP_Kante
-import org.eclipse.set.model.planpro.Geodaten.TOP_Knoten
+import java.math.BigDecimal
 import java.util.Comparator
 import java.util.HashSet
 import java.util.LinkedList
@@ -20,6 +17,10 @@ import java.util.Set
 import org.eclipse.core.runtime.Assert
 import org.eclipse.set.basis.graph.AbstractDirectedEdgePath
 import org.eclipse.set.basis.graph.DirectedEdge
+import org.eclipse.set.model.planpro.Basisobjekte.Bereich_Objekt
+import org.eclipse.set.model.planpro.Basisobjekte.Punkt_Objekt_TOP_Kante_AttributeGroup
+import org.eclipse.set.model.planpro.Geodaten.TOP_Kante
+import org.eclipse.set.model.planpro.Geodaten.TOP_Knoten
 import org.eclipse.set.ppmodel.extensions.exception.EndOfTopPathNotFound
 
 import static extension org.eclipse.set.ppmodel.extensions.BereichObjektExtensions.*
@@ -189,9 +190,9 @@ class TopKantePath extends AbstractDirectedEdgePath<TOP_Kante, TOP_Knoten, Punkt
 	}
 
 	override getDistanceComparator() {
-		return new Comparator<Double>() {
-			override compare(Double d1, Double d2) {
-				return Distance.compare(d1, d2)
+		return new Comparator<BigDecimal>() {
+			override compare(BigDecimal d1, BigDecimal d2) {
+				return new Distance().compare(d1, d2)
 			}
 		}
 	}

--- a/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/TopRouting.xtend
+++ b/java/bundles/org.eclipse.set.ppmodel.extensions/src/org/eclipse/set/ppmodel/extensions/utils/TopRouting.xtend
@@ -8,6 +8,8 @@
  */
 package org.eclipse.set.ppmodel.extensions.utils
 
+import java.math.BigDecimal
+import java.util.Comparator
 import org.eclipse.core.runtime.Assert
 import org.eclipse.set.basis.graph.AbstractRouting
 import org.eclipse.set.basis.graph.Routing
@@ -15,7 +17,6 @@ import org.eclipse.set.model.planpro.Basisobjekte.Punkt_Objekt_TOP_Kante_Attribu
 import org.eclipse.set.model.planpro.Geodaten.TOP_Kante
 import org.eclipse.set.model.planpro.Geodaten.TOP_Knoten
 import org.eclipse.set.ppmodel.extensions.TopKanteExtensions
-import java.util.Comparator
 
 import static extension org.eclipse.set.ppmodel.extensions.TopKanteExtensions.*
 import static extension org.eclipse.set.ppmodel.extensions.TopKnotenExtensions.*
@@ -47,9 +48,9 @@ class TopRouting extends AbstractRouting<TOP_Kante, TOP_Knoten, Punkt_Objekt_TOP
 	}
 
 	override getDistanceComparator() {
-		return new Comparator<Double>() {
-			override compare(Double d1, Double d2) {
-				return Distance.compare(d1, d2)
+		return new Comparator<BigDecimal>() {
+			override compare(BigDecimal d1, BigDecimal d2) {
+				return new Distance().compare(d1, d2)
 			}
 		}
 	}


### PR DESCRIPTION
In Java Double values are represented as IEEE floating point numbers. Therefore calculation of Topology Data may not be correct due to precision issues. BigDecimal will be used instead of Double to avoid this issues. 