### PR TITLE
Fix table cell compare error

### DIFF
--- a/java/bundles/org.eclipse.set.utils.table/src/org/eclipse/set/utils/table/sorting/AbstractCellComparator.xtend
+++ b/java/bundles/org.eclipse.set.utils.table/src/org/eclipse/set/utils/table/sorting/AbstractCellComparator.xtend
@@ -64,22 +64,9 @@ package abstract class AbstractCellComparator implements Comparator<TableCell> {
 		CompareCellContent c1,
 		CompareCellContent c2
 	) {
-
-		val newResult = c1.newValue.compareDispatch(c2.newValue)
-
-		if (newResult != 0) {
-			return newResult
-		}
-
-		val oldResult = c1.oldValue.compareDispatch(c2.oldValue)
-		if (oldResult != 0) {
-			return oldResult
-		}
-		val mix1 = c1.newValue.compareDispatch(c2.oldValue)
-		if (mix1 != 0) {
-			return mix1
-		}
-		return c1.oldValue.compareDispatch(c2.newValue)
+		// To avoid compare error, the compare cell shouldn't separate compare new/old value 
+		return c1.compareCellContentString.compareCell(
+			c2.compareCellContentString)
 	}
 
 	private def dispatch compareDispatch(List<String> value1,
@@ -116,8 +103,7 @@ package abstract class AbstractCellComparator implements Comparator<TableCell> {
 
 	private def dispatch int compareDispatch(CompareTableCellContent c1,
 		CompareTableCellContent c2) {
-		return c1.mainPlanCellContent.compareDispatch(
-			c2.mainPlanCellContent)
+		return c1.mainPlanCellContent.compareDispatch(c2.mainPlanCellContent)
 	}
 
 	private def Iterable<String> compareCellContentString(


### PR DESCRIPTION
By `CellComparator` is often error, because the result of comparator between two `CompareCellContent` and `StringCellContent` - `CompareCellContent` are implausible. Example:
    - CompareCellContent (new: 40N2 / old: N2) > CompareCellContent (new: "" /old: LW27Y ) (only compare old value N2 vs LW27Y)
    - CompareCellContent (new: 40N2 / old: N2) < StringCellContent (40N3) - compare (40N2N2 vs 40N3)
    - CompareCellContent (new: "" /old: LW27Y ) > StringCellContent (40N3) - compare (LW27Y vs 40N3)

Therefore by comapre two CompareCellContent will compare like CompareCellContent vs StringCellContent, also convert CompareCellContent to String with newValue at start and old value at the end (like 40N2N2) and