### PR TITLE
fix table-diff-view condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
   table-diff-view:
     runs-on: ubuntu-latest
     needs: swtbot
-    if: (needs.swtbot.result == 'success' || needs.swtbot.result == 'failure') && github.actor_id != 49699333 && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/')
+    if: always() && (needs.swtbot.result == 'success' || needs.swtbot.result == 'failure') && github.actor_id != 49699333 && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/')
     container: ghcr.io/eclipse-set/table-diff-view:latest
     permissions:
       contents: write


### PR DESCRIPTION
Since the `if` expression of the table-diff-view job was not including any of `success()`, `always()`, `failure()` or `cancelled()` it was automatically prefixed by`success() && ` leading to the situation that the job only ran if the swt bot job was successful.

Regression of #2462. 